### PR TITLE
refactor: eliminar console.log de debugging

### DIFF
--- a/src/controllers/suppliers.js
+++ b/src/controllers/suppliers.js
@@ -55,16 +55,12 @@ const getRecord = async(req, res) => {
  */
 const addRecord = async(req, res) => {
   try {
-    console.log('[addRecord] Iniciando...');
     req = matchedData(req);
-    console.log('[addRecord] Datos:', req);
 
     const supplier = await addNewSupplier(req);
-    console.log('[addRecord] Proveedor creado:', supplier);
 
     res.send({ supplier });
   } catch (error) {
-    console.error('[addRecord ERROR]', error.message, error.stack);
     handleHttpError(res, `ERROR_ADDING_RECORD --> ${error}`, 400);
   }
 };

--- a/src/middlewares/rol.js
+++ b/src/middlewares/rol.js
@@ -12,9 +12,7 @@ const { ROLE } = require('../constants/roles');
  */
 const checkRol = (roles, codename) => async(req, res, next) => {
   try {
-    console.log('[checkRol] Iniciando. Roles:', roles, 'Codename:', codename);
     const { user } = req;
-    console.log('[checkRol] User:', user?.id, user?.role);
 
     const rolesByUser = user.role;
 
@@ -38,7 +36,6 @@ const checkRol = (roles, codename) => async(req, res, next) => {
 
     next();
   } catch (error) {
-    console.error('[checkRol ERROR]', error.message, error.stack);
     handleHttpError(res, ERR_SECURITY.NOT_PERMISION, 403);
   }
 };


### PR DESCRIPTION
## Resumen

Limpieza de código removiendo `console.log` y `console.error` que fueron agregados temporalmente durante el debugging de los tests de integración.

## Cambios

- **src/controllers/suppliers.js** - Eliminados 4 console.log de debugging en `addRecord()`
- **src/middlewares/rol.js** - Eliminados 3 console.log de debugging en `checkRol()`

## Justificación

Estos logs fueron útiles para identificar y corregir errores durante el desarrollo de los tests, pero no deben estar en producción porque:

- Ensucian los logs del servidor
- Pueden afectar el rendimiento
- Podrían exponer información sensible

## Tests

✅ Todos los tests pasan (734/734)  
✅ Linter limpio