### PR TITLE
fix(privileges): filter soft-deleted privileges in user endpoint

### DIFF
--- a/src/services/user-privileges.js
+++ b/src/services/user-privileges.js
@@ -10,7 +10,8 @@ const getAllUserPrivileges = async(userId) => {
       {
         model: privileges,
         as: 'privileges',
-        attributes: ['name', 'codename']
+        attributes: ['name', 'codename'],
+        required: true // INNER JOIN - solo trae privilegios NO eliminados
       }
     ]
   });


### PR DESCRIPTION
When fetching user privileges via /privileges/user/:id, soft-deleted privileges were appearing in the response due to a LEFT JOIN. Changed the include to required: true to perform an INNER JOIN, ensuring only active privileges are returned.

Fixes soft delete filtering issue in user-privileges service.