### PR TITLE
feat(branches): add public endpoint for active branches

### DIFF
--- a/src/controllers/branches.js
+++ b/src/controllers/branches.js
@@ -1,7 +1,7 @@
 const { matchedData } = require('express-validator');
 const { handleHttpError } = require('../utils/handleErorr');
 
-const { getAllBranches, getBranch, addNewBranch, updateBranch, deleteBranch } = require('../services/branches');
+const { getAllBranches, getBranch, addNewBranch, updateBranch, deleteBranch, getPublicBranches } = require('../services/branches');
 
 /**
  * Obtener lista de registros
@@ -86,4 +86,13 @@ const deleteRecord = async(req, res) => {
   }
 };
 
-module.exports = { getRecord, getRecords, addRecord, updateRecord, deleteRecord };
+const getPublicRecords = async (req, res) => {
+  try {
+    const branches = await getPublicBranches();
+    res.send({ branches });
+  } catch (error) {
+    handleHttpError(res, `ERROR_GET_PUBLIC_BRANCHES -> ${error}`);
+  }
+};
+
+module.exports = { getRecord, getRecords, addRecord, updateRecord, deleteRecord, getPublicRecords };

--- a/src/routes/branches.js
+++ b/src/routes/branches.js
@@ -7,9 +7,23 @@ const authMidleware = require('../middlewares/session');
 const checkRol = require('../middlewares/rol');
 const { readLimiter, writeLimiter, deleteLimiter } = require('../middlewares/rateLimiters');
 
-const { getRecord, getRecords, addRecord, updateRecord, deleteRecord } = require('../controllers/branches');
+const { getRecord, getRecords, addRecord, updateRecord, deleteRecord, getPublicRecords } = require('../controllers/branches');
 const { BRANCH } = require('../constants/modules');
 const { ROLE } = require('../constants/roles');
+
+/**
+ * @openapi
+ * /branches/public:
+ *   get:
+ *     tags:
+ *       - branches
+ *     summary: Sucursales activas (público)
+ *     description: Lista de sucursales activas sin requerir autenticación. Uso previsto para landing page.
+ *     responses:
+ *       '200':
+ *         description: Arreglo de sucursales con nombre, dirección, teléfono, municipio y fecha de apertura.
+ */
+router.get('/public', [readLimiter], getPublicRecords);
 
 /**
  * Get all states

--- a/src/services/branches.js
+++ b/src/services/branches.js
@@ -1,4 +1,4 @@
-const { branches, municipalities } = require('../models/index');
+const { branches, municipalities, states } = require('../models/index');
 
 const attributes = [
   'id',
@@ -12,6 +12,8 @@ const attributes = [
   'deletedAt',
   'municipality_id'
 ];
+
+const publicAttributes = ['id', 'name', 'address', 'phone', 'opening_date'];
 
 const municipalityAttributes = ['id', 'name'];
 
@@ -102,10 +104,33 @@ const deleteBranch = async(id) => {
   return data;
 };
 
+const getPublicBranches = async () => {
+  return branches.findAll({
+    attributes: publicAttributes,
+    include: [
+      {
+        model: municipalities,
+        as: 'municipio',
+        attributes: municipalityAttributes,
+        required: true,
+        include: [
+          {
+            model: states,
+            as: 'estado',
+            attributes: ['id', 'name'],
+            required: true
+          }
+        ]
+      }
+    ]
+  });
+};
+
 module.exports = {
   getAllBranches,
   getBranch,
   addNewBranch,
   updateBranch,
-  deleteBranch
+  deleteBranch,
+  getPublicBranches
 };


### PR DESCRIPTION
## Summary

Adds a new public endpoint `GET /api/branches/public` that exposes active branches without requiring authentication or user privileges. This endpoint is intended for use on landing pages and location mapping features.

## Changes

- **Route** (`src/routes/branches.js`): New GET `/public` endpoint with rate limiting via `readLimiter` middleware. Includes OpenAPI/Swagger documentation.
- **Controller** (`src/controllers/branches.js`): New `getPublicRecords` handler that calls the service and returns branch data.
- **Service** (`src/services/branches.js`): New `getPublicBranches` function that queries branches with reduced attributes (id, name, address, phone, opening_date) and includes hierarchical municipality → state relationships for geographic context.

## Response Example

```json
{
  "branches": [
    {
      "id": 1,
      "name": "Sucursal Central",
      "address": "Calle Principal 123",
      "phone": "+58 2122345678",
      "opening_date": "2020-01-15",
      "municipio": {
        "id": 5,
        "name": "Libertador",
        "estado": {
          "id": 1,
          "name": "Distrito Capital"
        }
      }
    }
  ]
}
```

## Testing

- Endpoint is accessible without authentication
- Rate limiting is enforced via readLimiter
- Returns only active branches (default Sequelize behavior with paranoid: true)
- Includes complete geographic context via municipality and state relationships