### PR TITLE
fix: specify pnpm version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Sistema de administracion de mercancias Estelaris",
   "main": "index.js",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "start": "node ./app.js",
     "dev": "nodemon ./app.js",


### PR DESCRIPTION
## Summary

Adds the `packageManager` field to package.json to explicitly declare pnpm@10.33.0 as the required package manager for this project.

## Problem

Railway deployments were failing because Railpack couldn't determine the correct pnpm version from the configuration. It fell back to inferring version 9 from the lockfile format, causing installation mismatches and build failures.

## Solution

The `packageManager` field (npm standard) provides Railpack with explicit version information, ensuring:
- Railway uses the correct pnpm version during deployment
- Consistent tooling across all environments
- No more version inference errors

## Testing

- Package installation tested locally with pnpm@10.33.0
- No functional changes to the codebase
- Ready for Railway deployment

## Related Issues

Fixes Railway deployment failure due to pnpm version resolution.