### PR TITLE
feat(campaignProducts): agregar búsqueda a endpoint de productos de campaña

### DIFF
--- a/src/controllers/campaignProducts.js
+++ b/src/controllers/campaignProducts.js
@@ -25,8 +25,9 @@ const getProductsByCampaign = async(req, res) => {
   try {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
+    const search = data.search || '';
     // eslint-disable-next-line camelcase
-    const { products, total } = await campaignProductsService.getProductsByCampaign(data.campaign_id, page, limit);
+    const { products, total } = await campaignProductsService.getProductsByCampaign(data.campaign_id, page, limit, search);
 
     res.status(200).json({
       ok: true,

--- a/src/routes/campaignProducts.js
+++ b/src/routes/campaignProducts.js
@@ -60,6 +60,24 @@ const handleValidationErrors = (req, res, next) => {
  *         schema:
  *           type: integer
  *         description: ID de la campaña
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Número de página
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *         description: Resultados por página
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Buscar por nombre de producto
  *     responses:
  *       200:
  *         description: Productos obtenidos correctamente

--- a/src/services/campaignProducts.js
+++ b/src/services/campaignProducts.js
@@ -1,3 +1,4 @@
+const { Op } = require('sequelize');
 const { campaignProducts: CampaignProducts, campaignProductBranches: CampaignProductBranches, campaigns: Campaigns, products: Products, branches: Branches } = require('../models');
 
 /**
@@ -5,7 +6,7 @@ const { campaignProducts: CampaignProducts, campaignProductBranches: CampaignPro
  * @param {number} campaignId - ID de la campaña
  * @returns {Promise<Array>}
  */
-const getProductsByCampaign = async(campaignId, page = 1, limit = 20) => {
+const getProductsByCampaign = async(campaignId, page = 1, limit = 20, search = '') => {
   const offset = (page - 1) * limit;
   const { count, rows } = await CampaignProducts.findAndCountAll({
     where: { campaign_id: campaignId },
@@ -13,7 +14,8 @@ const getProductsByCampaign = async(campaignId, page = 1, limit = 20) => {
       {
         model: Products,
         as: 'product',
-        attributes: ['id', 'name', 'base_price', 'description']
+        attributes: ['id', 'name', 'base_price', 'description'],
+        ...(search ? { where: { name: { [Op.like]: `%${search}%` } }, required: true } : {})
       },
       {
         model: CampaignProductBranches,

--- a/src/validators/campaignProducts.js
+++ b/src/validators/campaignProducts.js
@@ -1,4 +1,4 @@
-const { body, param } = require('express-validator');
+const { body, param, check } = require('express-validator');
 const { paginationChecks } = require('./shared');
 
 const createCampaignProductValidator = [
@@ -89,7 +89,8 @@ const getProductsByCampaignValidator = [
     .exists().withMessage('El ID de la campaña es requerido')
     .isInt({ min: 1 }).withMessage('El ID de la campaña debe ser un número entero positivo')
     .toInt(),
-  ...paginationChecks
+  ...paginationChecks,
+  check('search').optional().isString().trim().isLength({ max: 100 }).withMessage('search no puede superar 100 caracteres')
 ];
 
 const createBranchOverrideValidator = [


### PR DESCRIPTION
## Resumen

Implementa funcionalidad de búsqueda en el endpoint GET `/api/campaignProducts/campaign/:campaign_id` para filtrar productos por nombre. Se añade soporte completo de paginación con parámetros de página, límite y búsqueda en la consulta.

### Cambios

- **Validador**: Añade validación para parámetro `search` (máximo 100 caracteres)
- **Controlador**: Extrae el parámetro `search` de `matchedData()` y lo pasa al servicio
- **Servicio**: Implementa filtrado de productos por nombre usando `Sequelize Op.like` (búsqueda case-insensitive)
- **Rutas/Swagger**: Documenta los nuevos parámetros de paginación y búsqueda en las especificaciones OpenAPI

### Compatibilidad

- El parámetro `search` es opcional, manteniendo compatibilidad hacia atrás
- Los parámetros `page` y `limit` ya estaban implementados
- Funcionalidad implementada según el patrón de búsqueda universal del proyecto

### Testing

- Validación de formato correcta
- Pruebas de integración pasando
- Linting aplicado automáticamente