### PR TITLE
feat(reports): add daily movement report endpoint

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -1546,6 +1546,102 @@ const swaggerDefinition = {
           updated_at: { type: 'string', format: 'date-time' },
           deleted_at: { type: 'string', format: 'date-time', nullable: true }
         }
+      },
+      dailyMovementReport: {
+        type: 'object',
+        description: 'Reporte de movimiento diario de una sucursal',
+        properties: {
+          credits: {
+            type: 'array',
+            description: 'Una fila por ítem de venta a crédito del día (no canceladas)',
+            items: {
+              type: 'object',
+              properties: {
+                saleId: { type: 'integer' },
+                productName: { type: 'string' },
+                customerName: { type: 'string' },
+                customerAddress: { type: 'string', nullable: true },
+                unitPrice: { type: 'number', format: 'decimal' },
+                anticipo: { type: 'number', format: 'decimal' },
+                duePayment: { type: 'number', format: 'decimal' },
+                paymentPeriod: { type: 'string', nullable: true, enum: ['Semanal', 'Quincenal', 'Mensual'] }
+              }
+            }
+          },
+          cash: {
+            type: 'array',
+            description: 'Una fila por ítem de venta de contado del día (no canceladas)',
+            items: {
+              type: 'object',
+              properties: {
+                saleId: { type: 'integer' },
+                qty: { type: 'number', format: 'decimal' },
+                productName: { type: 'string' },
+                customerName: { type: 'string' },
+                unitPrice: { type: 'number', format: 'decimal' },
+                subtotal: { type: 'number', format: 'decimal' }
+              }
+            }
+          },
+          expenses: {
+            type: 'array',
+            description: 'Gastos registrados en el día',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer' },
+                amount: { type: 'number', format: 'decimal' },
+                concept: { type: 'string' },
+                notes: { type: 'string', nullable: true }
+              }
+            }
+          },
+          payments: {
+            type: 'array',
+            description: 'Abonos recibidos en el día',
+            items: {
+              type: 'object',
+              properties: {
+                saleId: { type: 'integer' },
+                customerName: { type: 'string' },
+                paymentDate: { type: 'string', format: 'date' },
+                amount: { type: 'number', format: 'decimal' },
+                remainingDue: { type: 'number', format: 'decimal' }
+              }
+            }
+          },
+          transfersSent: {
+            type: 'array',
+            description: 'Transferencias enviadas desde esta sucursal (no canceladas)',
+            items: {
+              type: 'object',
+              properties: {
+                transferId: { type: 'integer' },
+                toBranchName: { type: 'string' }
+              }
+            }
+          },
+          transfersReceived: {
+            type: 'array',
+            description: 'Transferencias recibidas en esta sucursal (status Recibido)',
+            items: {
+              type: 'object',
+              properties: {
+                transferId: { type: 'integer' },
+                fromBranchName: { type: 'string' }
+              }
+            }
+          },
+          totals: {
+            type: 'object',
+            properties: {
+              anticipos: { type: 'number', format: 'decimal', description: 'Suma de anticipo_amount de ventas a crédito' },
+              cashSales: { type: 'number', format: 'decimal', description: 'Suma de subtotales de ítems de contado' },
+              expenses: { type: 'number', format: 'decimal', description: 'Suma de gastos' },
+              payments: { type: 'number', format: 'decimal', description: 'Suma de abonos recibidos' }
+            }
+          }
+        }
       }
     }
   }

--- a/src/controllers/reports.js
+++ b/src/controllers/reports.js
@@ -1,0 +1,15 @@
+const { matchedData } = require('express-validator');
+const { handleHttpError } = require('../utils/handleErorr');
+const { getDailyMovement } = require('../services/reports');
+
+const getDailyMovementReport = async (req, res) => {
+  try {
+    const { branch_id: branchId, date } = matchedData(req);
+    const report = await getDailyMovement(branchId, date);
+    res.send({ report });
+  } catch (error) {
+    handleHttpError(res, `ERROR_GET_DAILY_MOVEMENT -> ${error}`);
+  }
+};
+
+module.exports = { getDailyMovementReport };

--- a/src/routes/reports.js
+++ b/src/routes/reports.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const router = express.Router();
+
+const { validateDailyMovement } = require('../validators/reports');
+const authMiddleware = require('../middlewares/session');
+const checkRol = require('../middlewares/rol');
+const { readLimiter } = require('../middlewares/rateLimiters');
+const { getDailyMovementReport } = require('../controllers/reports');
+const { SALE } = require('../constants/modules');
+const { ROLE } = require('../constants/roles');
+
+/**
+ * @openapi
+ * /reports/daily-movement:
+ *   get:
+ *     tags:
+ *       - reports
+ *     summary: Reporte de movimiento diario por sucursal
+ *     description: |
+ *       Consolida en una sola respuesta los movimientos del día para una sucursal:
+ *       ventas a crédito, ventas de contado, gastos, abonos recibidos, transferencias
+ *       enviadas y transferencias recibidas. Incluye totales pre-calculados.
+ *       Requiere el privilegio `view_sales`.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: branch_id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: ID de la sucursal a consultar
+ *       - in: query
+ *         name: date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: "2026-04-29"
+ *         description: Fecha del reporte en formato YYYY-MM-DD
+ *     responses:
+ *       '200':
+ *         description: Reporte de movimiento diario
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 report:
+ *                   $ref: '#/components/schemas/dailyMovementReport'
+ *       '400':
+ *         description: Parámetros inválidos (branch_id o date faltante/incorrecto)
+ *       '403':
+ *         description: Sin privilegio view_sales
+ */
+router.get('/daily-movement', [
+  readLimiter,
+  authMiddleware,
+  validateDailyMovement,
+  checkRol([ROLE.USER, ROLE.ADMIN], SALE.VIEW_ALL)
+], getDailyMovementReport);
+
+module.exports = router;

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -1,0 +1,140 @@
+const { sequelize } = require('../models');
+
+const getDailyMovement = async (branchId, date) => {
+  const replacements = { branch_id: branchId, date };
+
+  const [credits, cash, expenses, payments, transfersSent, transfersReceived] = await Promise.all([
+    sequelize.query(`
+      SELECT
+        sd.sale_id          AS saleId,
+        p.name              AS productName,
+        c.name              AS customerName,
+        TRIM(CONCAT(ca.street,
+          CASE WHEN ca.neighborhood IS NOT NULL AND ca.neighborhood != ''
+            THEN CONCAT(', ', ca.neighborhood) ELSE '' END
+        ))                  AS customerAddress,
+        sd.unit_price       AS unitPrice,
+        s.anticipo_amount   AS anticipo,
+        s.due_payment       AS duePayment,
+        s.payment_periods   AS paymentPeriod
+      FROM sales s
+      INNER JOIN sale_details sd ON sd.sale_id = s.id
+      INNER JOIN products p      ON p.id = sd.product_id AND p.deleted_at IS NULL
+      INNER JOIN customers c     ON c.id = s.customer_id AND c.deleted_at IS NULL
+      LEFT  JOIN customer_addresses ca ON ca.id = s.customer_address_id
+      WHERE s.branch_id   = :branch_id
+        AND s.sales_date  = :date
+        AND s.status     != 'Cancelado'
+        AND s.sales_type  = 'Credito'
+        AND s.deleted_at IS NULL
+      ORDER BY s.id, sd.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT }),
+
+    sequelize.query(`
+      SELECT
+        sd.sale_id    AS saleId,
+        sd.qty,
+        p.name        AS productName,
+        c.name        AS customerName,
+        sd.unit_price AS unitPrice,
+        sd.subtotal
+      FROM sales s
+      INNER JOIN sale_details sd ON sd.sale_id = s.id
+      INNER JOIN products p      ON p.id = sd.product_id AND p.deleted_at IS NULL
+      INNER JOIN customers c     ON c.id = s.customer_id AND c.deleted_at IS NULL
+      WHERE s.branch_id   = :branch_id
+        AND s.sales_date  = :date
+        AND s.status     != 'Cancelado'
+        AND s.sales_type  = 'Contado'
+        AND s.deleted_at IS NULL
+      ORDER BY s.id, sd.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT }),
+
+    sequelize.query(`
+      SELECT
+        e.id,
+        e.expense_amount AS amount,
+        et.name          AS concept,
+        e.notes
+      FROM expenses e
+      INNER JOIN expense_types et ON et.id = e.expense_type_id
+      WHERE e.branch_id    = :branch_id
+        AND e.trans_date   = :date
+        AND e.deleted_at  IS NULL
+      ORDER BY e.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT }),
+
+    sequelize.query(`
+      SELECT
+        sp.sale_id          AS saleId,
+        c.name              AS customerName,
+        sp.payment_date     AS paymentDate,
+        sp.payment_amount   AS amount,
+        s.due_payment       AS remainingDue
+      FROM sale_payments sp
+      INNER JOIN sales s     ON s.id = sp.sale_id AND s.deleted_at IS NULL
+      INNER JOIN customers c ON c.id = s.customer_id AND c.deleted_at IS NULL
+      WHERE sp.branch_id    = :branch_id
+        AND sp.payment_date = :date
+        AND sp.deleted_at  IS NULL
+      ORDER BY sp.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT }),
+
+    sequelize.query(`
+      SELECT
+        t.id   AS transferId,
+        b.name AS toBranchName
+      FROM transfers t
+      INNER JOIN branches b ON b.id = t.to_branch_id AND b.deleted_at IS NULL
+      WHERE t.from_branch_id  = :branch_id
+        AND t.transfer_date   = :date
+        AND t.status         != 'Cancelado'
+        AND t.deleted_at     IS NULL
+      ORDER BY t.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT }),
+
+    sequelize.query(`
+      SELECT
+        t.id   AS transferId,
+        b.name AS fromBranchName
+      FROM transfers t
+      INNER JOIN branches b ON b.id = t.from_branch_id AND b.deleted_at IS NULL
+      WHERE t.to_branch_id  = :branch_id
+        AND t.transfer_date = :date
+        AND t.status        = 'Recibido'
+        AND t.deleted_at   IS NULL
+      ORDER BY t.id
+    `, { replacements, type: sequelize.QueryTypes.SELECT })
+  ]);
+
+  // Compute totals; credits has one row per detail so deduplicate on saleId for anticipo
+  const seenSaleIds = new Set();
+  let anticipos = 0;
+  for (const row of credits) {
+    if (!seenSaleIds.has(row.saleId)) {
+      seenSaleIds.add(row.saleId);
+      anticipos += parseFloat(row.anticipo) || 0;
+    }
+  }
+
+  const cashSales = cash.reduce((sum, r) => sum + (parseFloat(r.subtotal) || 0), 0);
+  const expensesTotal = expenses.reduce((sum, r) => sum + (parseFloat(r.amount) || 0), 0);
+  const paymentsTotal = payments.reduce((sum, r) => sum + (parseFloat(r.amount) || 0), 0);
+
+  return {
+    credits,
+    cash,
+    expenses,
+    payments,
+    transfersSent,
+    transfersReceived,
+    totals: {
+      anticipos: Math.round(anticipos * 100) / 100,
+      cashSales: Math.round(cashSales * 100) / 100,
+      expenses: Math.round(expensesTotal * 100) / 100,
+      payments: Math.round(paymentsTotal * 100) / 100
+    }
+  };
+};
+
+module.exports = { getDailyMovement };

--- a/src/validators/reports.js
+++ b/src/validators/reports.js
@@ -1,0 +1,15 @@
+const { query } = require('express-validator');
+const validateResults = require('../utils/handleValidator');
+
+const validateDailyMovement = [
+  query('branch_id')
+    .notEmpty().withMessage('branch_id es requerido')
+    .isInt({ min: 1 }).withMessage('branch_id debe ser un número entero positivo')
+    .toInt(),
+  query('date')
+    .notEmpty().withMessage('date es requerida')
+    .isDate({ format: 'YYYY-MM-DD' }).withMessage('date debe tener formato YYYY-MM-DD'),
+  (req, res, next) => validateResults(req, res, next)
+];
+
+module.exports = { validateDailyMovement };


### PR DESCRIPTION
## Summary

Add a new `GET /api/reports/daily-movement?branch_id=X&date=YYYY-MM-DD` endpoint that consolidates 5 separate frontend requests into one optimized backend query.

The endpoint executes 6 SQL queries in parallel (credits, cash sales, expenses, payments, transfers sent, transfers received) and returns pre-calculated daily totals. Requires `view_sales` privilege.

## Changes

- **src/validators/reports.js** — Input validation for branch_id (required, positive integer) and date (required, YYYY-MM-DD format)
- **src/services/reports.js** — Core logic: 6 parallel queries + total calculations with deduplication for credit anticipos
- **src/controllers/reports.js** — HTTP handler with error management
- **src/routes/reports.js** — OpenAPI documentation + middleware chain (auth, validation, RBAC, rate limiting)
- **docs/swagger.js** — `dailyMovementReport` schema with detailed field definitions

## Test Plan

- [ ] Endpoint accepts valid branch_id and date parameters
- [ ] Returns empty arrays for days with no transactions
- [ ] Correctly aggregates totals from all 6 data sources
- [ ] Handles soft-deleted records (excluded from results)
- [ ] Returns 403 when user lacks view_sales privilege
- [ ] Returns 400 for invalid branch_id or date format
- [ ] Verifies response matches Swagger schema