### PR TITLE
Add payment_type field to sale_payments

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -1135,7 +1135,13 @@ const swaggerDefinition = {
           payment_method: { type: 'string', enum: ['Efectivo', 'Transferencia', 'Vale despensa', 'Tarjeta'] },
           reference_number: { type: 'string', maxLength: 100, nullable: true },
           user_id: { type: 'integer' },
+          branch_id: { type: 'integer' },
           notes: { type: 'string', nullable: true },
+          payment_type: {
+            type: 'string',
+            enum: ['Anticipo', 'Abono'],
+            description: 'Asignado automáticamente por el backend. Anticipo: pago inicial al crear la venta. Abono: pago posterior al saldo pendiente.'
+          },
           created_at: { type: 'string', format: 'date-time' },
           updated_at: { type: 'string', format: 'date-time' }
         }

--- a/src/database/migrations/20260429000000-add-payment-type-to-sale-payments.js
+++ b/src/database/migrations/20260429000000-add-payment-type-to-sale-payments.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('sale_payments', 'payment_type', {
+      type: Sequelize.ENUM('Anticipo', 'Abono'),
+      allowNull: false,
+      defaultValue: 'Abono',
+      after: 'notes'
+    });
+
+    await queryInterface.sequelize.query(
+      'UPDATE sale_payments SET payment_type = \'Anticipo\' WHERE notes = \'Anticipo\''
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('sale_payments', 'payment_type');
+  }
+};

--- a/src/models/salePayments.js
+++ b/src/models/salePayments.js
@@ -42,6 +42,11 @@ module.exports = (sequelize, DataTypes) => {
     notes: {
       type: DataTypes.TEXT,
       allowNull: true
+    },
+    payment_type: {
+      type: DataTypes.ENUM('Anticipo', 'Abono'),
+      allowNull: false,
+      defaultValue: 'Abono'
     }
   }, {
     sequelize,

--- a/src/routes/sale-payments.js
+++ b/src/routes/sale-payments.js
@@ -202,7 +202,7 @@ router.get('/:id', [
  *                  type: string
  *      responses:
  *        '200':
- *          description: Cobro registrado correctamente
+ *          description: Cobro registrado. El campo `payment_type` es asignado automáticamente por el backend como `Abono`.
  *          content:
  *            application/json:
  *              schema:

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -78,6 +78,7 @@ const getDailyMovement = async (branchId, date) => {
       INNER JOIN customers c ON c.id = s.customer_id AND c.deleted_at IS NULL
       WHERE sp.branch_id    = :branch_id
         AND sp.payment_date = :date
+        AND sp.payment_type = 'Abono'
         AND sp.deleted_at  IS NULL
       ORDER BY sp.id
     `, { replacements, type: sequelize.QueryTypes.SELECT }),

--- a/src/services/salePayments.js
+++ b/src/services/salePayments.js
@@ -4,7 +4,7 @@ const accountingEngine = require('./accountingEngine.service');
 
 const paymentAttributes = [
   'id', 'sale_id', 'payment_amount', 'payment_date', 'payment_method',
-  'reference_number', 'user_id', 'branch_id', 'notes', 'created_at', 'updated_at'
+  'reference_number', 'user_id', 'branch_id', 'notes', 'payment_type', 'created_at', 'updated_at'
 ];
 
 const userAttributes = ['id', 'name', 'email'];
@@ -160,7 +160,8 @@ const createPayment = async (body, userId, branchId) => {
       reference_number: referenceNumber || null,
       user_id: userId,
       branch_id: branchId,
-      notes: notes || null
+      notes: notes || null,
+      payment_type: 'Abono'
     }, { transaction });
 
     await saleForUpdate.update(

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -426,6 +426,7 @@ const createSale = async (body, userId) => {
         payment_date: salesDate,
         payment_method: antizipoPaymentMethod,
         notes: 'Anticipo',
+        payment_type: 'Anticipo',
         user_id: userId,
         branch_id: branchId
       }, { transaction });


### PR DESCRIPTION
## Summary

- Add `payment_type` ENUM field ('Anticipo', 'Abono') to sale_payments table
- Distinguish advance payments (created at sale time) from installment payments (created via payments endpoint)
- Fix double-counting bug in daily movement report by filtering only 'Abono' payments
- Auto-assign payment_type by backend logic (not user-provided)

## Test Plan

- [ ] Run migrations: `npm run db:reset` to verify migration executes without error
- [ ] Verify existing 'Anticipo' payments are correctly identified and marked during migration
- [ ] Create a new sale with advance payment and verify payment_type='Anticipo'
- [ ] Create installment payment via POST /api/sale-payments and verify payment_type='Abono'
- [ ] Run daily movement report endpoint and verify only 'Abono' payments are counted
- [ ] Verify Swagger documentation displays payment_type field with correct enum values