### PR TITLE
fix(sale-payments): use payment_date for installment.paid_date

### DIFF
--- a/src/services/salePayments.js
+++ b/src/services/salePayments.js
@@ -57,7 +57,7 @@ const getPayment = async (id) => {
   });
 };
 
-const applyPaymentToInstallments = async (saleId, amount, transaction) => {
+const applyPaymentToInstallments = async (saleId, amount, paymentDate, transaction) => {
   const pendingInstallments = await saleInstallments.findAll({
     where: { sale_id: saleId, status: 'Pendiente' },
     order: [['installment_number', 'ASC']],
@@ -66,7 +66,6 @@ const applyPaymentToInstallments = async (saleId, amount, transaction) => {
   });
 
   let remaining = amount;
-  const today = new Date().toISOString().split('T')[0];
 
   for (const installment of pendingInstallments) {
     if (remaining <= 0) break;
@@ -78,7 +77,7 @@ const applyPaymentToInstallments = async (saleId, amount, transaction) => {
 
     if (installment.paid_amount >= parseFloat(installment.amount)) {
       installment.status = 'Pagado';
-      installment.paid_date = today;
+      installment.paid_date = paymentDate;
     }
 
     await installment.save({ transaction });
@@ -171,7 +170,7 @@ const createPayment = async (body, userId, branchId) => {
 
     // Auto-apply to installments
     if (sale.sales_type === 'Credito') {
-      await applyPaymentToInstallments(saleId, amount, transaction);
+      await applyPaymentToInstallments(saleId, amount, paymentDate, transaction);
     }
 
     await transaction.commit();


### PR DESCRIPTION
## Summary

Fixed a critical bug where `sale_installments.paid_date` was being set using `new Date()` (UTC) instead of the `payment_date` from the payment request. This caused off-by-one date errors for users in UTC-6 timezones after 6pm local time.

## Changes

- Modified `applyPaymentToInstallments` in `src/services/salePayments.js` to accept `paymentDate` as a parameter
- Updated the method to use the provided `paymentDate` when setting `installment.paid_date` instead of calling `new Date()` at execution time
- Ensures timezone-aware dates are preserved throughout the payment workflow

## Test plan

- [ ] Run existing test suite: `npm test`
- [ ] Verify installment payment dates match the request timestamp for various timezones
- [ ] Test payments made after 6pm UTC-6 to confirm no off-by-one errors occur
- [ ] Check accounting engine vouchers use correct payment dates