### PR TITLE
feat(reports): add inventory report endpoint

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -1617,6 +1617,24 @@ const swaggerDefinition = {
           }
         }
       },
+      inventoryReportItem: {
+        type: 'object',
+        description: 'Fila del reporte de inventario por producto',
+        properties: {
+          productId: { type: 'string', maxLength: 20, description: 'Código SKU del producto' },
+          productName: { type: 'string', description: 'Nombre del producto' },
+          inicio: { type: 'number', format: 'decimal', description: 'Stock al inicio del periodo' },
+          compro: { type: 'number', format: 'decimal', description: 'Entradas por compras en el periodo' },
+          recibio: { type: 'number', format: 'decimal', description: 'Entradas por transferencias recibidas' },
+          cancelo: { type: 'number', format: 'decimal', description: 'Reingresos por cancelaciones de venta' },
+          envio: { type: 'number', format: 'decimal', description: 'Salidas por transferencias despachadas' },
+          contado: { type: 'number', format: 'decimal', description: 'Unidades vendidas en ventas de contado' },
+          credito: { type: 'number', format: 'decimal', description: 'Unidades vendidas en ventas a crédito' },
+          existencia: { type: 'number', format: 'decimal', description: 'inicio + compro + recibio + cancelo - envio - contado - credito' },
+          unitPrice: { type: 'number', format: 'decimal', description: 'Precio base unitario del producto' },
+          importe: { type: 'number', format: 'decimal', description: 'unitPrice × existencia' }
+        }
+      },
       dailyMovementReport: {
         type: 'object',
         description: 'Reporte de movimiento diario de una sucursal',

--- a/src/constants/modules.js
+++ b/src/constants/modules.js
@@ -455,7 +455,9 @@ const REPORTS = Object.freeze({
   VIEW_DAILY_MOVEMENT: 'view_daily_movement',
   NAME_DAILY_MOVEMENT: 'Ver reporte diario de movimientos',
   VIEW_ACCOUNTS_RECEIVABLE: 'view_accounts_receivable',
-  NAME_ACCOUNTS_RECEIVABLE: 'Ver reporte de cuentas por cobrar'
+  NAME_ACCOUNTS_RECEIVABLE: 'Ver reporte de cuentas por cobrar',
+  VIEW_INVENTORY: 'view_inventory',
+  NAME_INVENTORY: 'Ver reporte de inventario'
 });
 
 module.exports = {

--- a/src/controllers/reports.js
+++ b/src/controllers/reports.js
@@ -1,6 +1,6 @@
 const { matchedData } = require('express-validator');
 const { handleHttpError } = require('../utils/handleErorr');
-const { getDailyMovement, getAccountsReceivable } = require('../services/reports');
+const { getDailyMovement, getAccountsReceivable, getInventoryReport } = require('../services/reports');
 
 const getDailyMovementReport = async (req, res) => {
   try {
@@ -22,4 +22,14 @@ const getAccountsReceivableReport = async (req, res) => {
   }
 };
 
-module.exports = { getDailyMovementReport, getAccountsReceivableReport };
+const getInventoryReportController = async (req, res) => {
+  try {
+    const { branch_id: branchId, start_date: startDate, end_date: endDate } = matchedData(req);
+    const report = await getInventoryReport(branchId, startDate, endDate);
+    res.send({ report });
+  } catch (error) {
+    handleHttpError(res, `ERROR_GET_INVENTORY_REPORT -> ${error}`);
+  }
+};
+
+module.exports = { getDailyMovementReport, getAccountsReceivableReport, getInventoryReportController };

--- a/src/database/seeders/json_files/privileges.js
+++ b/src/database/seeders/json_files/privileges.js
@@ -195,7 +195,8 @@ const data = [
 
   // reports
   { name: REPORT.NAME_DAILY_MOVEMENT, codeName: REPORT.VIEW_DAILY_MOVEMENT, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha },
-  { name: REPORT.NAME_ACCOUNTS_RECEIVABLE, codeName: REPORT.VIEW_ACCOUNTS_RECEIVABLE, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha }
+  { name: REPORT.NAME_ACCOUNTS_RECEIVABLE, codeName: REPORT.VIEW_ACCOUNTS_RECEIVABLE, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha },
+  { name: REPORT.NAME_INVENTORY, codeName: REPORT.VIEW_INVENTORY, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha }
 
 ];
 

--- a/src/routes/reports.js
+++ b/src/routes/reports.js
@@ -1,11 +1,11 @@
 const express = require('express');
 const router = express.Router();
 
-const { validateDailyMovement, validateAccountsReceivable } = require('../validators/reports');
+const { validateDailyMovement, validateAccountsReceivable, validateInventoryReport } = require('../validators/reports');
 const authMiddleware = require('../middlewares/session');
 const checkRol = require('../middlewares/rol');
 const { readLimiter } = require('../middlewares/rateLimiters');
-const { getDailyMovementReport, getAccountsReceivableReport } = require('../controllers/reports');
+const { getDailyMovementReport, getAccountsReceivableReport, getInventoryReportController } = require('../controllers/reports');
 const { REPORTS } = require('../constants/modules');
 const { ROLE } = require('../constants/roles');
 
@@ -109,5 +109,76 @@ router.get('/accounts-receivable', [
   validateAccountsReceivable,
   checkRol([ROLE.USER, ROLE.ADMIN], REPORTS.VIEW_ACCOUNTS_RECEIVABLE)
 ], getAccountsReceivableReport);
+
+/**
+ * @openapi
+ * /reports/inventory:
+ *   get:
+ *     tags:
+ *       - reports
+ *     summary: Reporte de inventario por sucursal y periodo
+ *     description: |
+ *       Devuelve un listado de productos activos de la sucursal con los movimientos
+ *       de inventario ocurridos entre start_date y end_date (inclusive).
+ *       Para cada producto calcula:
+ *       - **inicio**: stock al inicio de start_date (stock actual menos movimientos del periodo en adelante).
+ *       - **compro**: entradas por compras (reference_type = 'purchase').
+ *       - **recibio**: entradas por transferencias recibidas (reference_type = 'transfer', qty > 0).
+ *       - **cancelo**: reingresos por cancelación de venta (reference_type = 'reversal').
+ *       - **envio**: salidas por transferencias despachadas (reference_type = 'transfer', qty < 0).
+ *       - **contado**: unidades vendidas en ventas de contado no canceladas.
+ *       - **credito**: unidades vendidas en ventas a crédito no canceladas.
+ *       - **existencia**: inicio + compro + recibio + cancelo - envio - contado - credito.
+ *       - **importe**: unitPrice × existencia.
+ *       Requiere el privilegio `view_inventory`.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: branch_id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: ID de la sucursal a consultar
+ *       - in: query
+ *         name: start_date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: "2026-01-01"
+ *         description: Fecha inicial del periodo en formato YYYY-MM-DD
+ *       - in: query
+ *         name: end_date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: "2026-04-30"
+ *         description: Fecha final del periodo en formato YYYY-MM-DD (debe ser >= start_date)
+ *     responses:
+ *       '200':
+ *         description: Reporte de inventario generado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 report:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/inventoryReportItem'
+ *       '400':
+ *         description: Parámetros inválidos (branch_id, start_date o end_date faltante/incorrecto)
+ *       '403':
+ *         description: Sin privilegio view_inventory
+ */
+router.get('/inventory', [
+  readLimiter,
+  authMiddleware,
+  validateInventoryReport,
+  checkRol([ROLE.USER, ROLE.ADMIN], REPORTS.VIEW_INVENTORY)
+], getInventoryReportController);
 
 module.exports = router;

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -296,4 +296,143 @@ const getAccountsReceivable = async (branchId) => {
   return { credits, summary };
 };
 
-module.exports = { getDailyMovement, getAccountsReceivable };
+const getInventoryReport = async (branchId, startDate, endDate) => {
+  const setting = await getSystemSetting('timezone');
+  const tz = setting?.value || 'America/Mexico_City';
+
+  // Compute UTC boundaries for local midnight using Intl (avoids MySQL timezone tables)
+  const localDayStartUTC = (dateStr) => {
+    const [y, m, d] = dateStr.split('-').map(Number);
+    // Use noon UTC as reference to safely compute the offset (avoids DST edge cases at midnight)
+    const noonUTC = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+    const toMs = (date, timezone) => {
+      const p = new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23'
+      }).formatToParts(date).filter(({ type }) => type !== 'literal');
+      const o = Object.fromEntries(p.map(({ type, value }) => [type, Number(value)]));
+      return Date.UTC(o.year, o.month - 1, o.day, o.hour, o.minute, o.second);
+    };
+    const offsetMs = toMs(noonUTC, 'UTC') - toMs(noonUTC, tz);
+    return new Date(Date.UTC(y, m - 1, d, 0, 0, 0) + offsetMs).toISOString().slice(0, 19).replace('T', ' ');
+  };
+
+  const startUTC = localDayStartUTC(startDate);
+  // endUTC is exclusive: start of the day AFTER end_date in local time
+  const endDayAfter = new Date(`${endDate}T00:00:00Z`);
+  endDayAfter.setUTCDate(endDayAfter.getUTCDate() + 1);
+  const endUTC = localDayStartUTC(endDayAfter.toISOString().slice(0, 10));
+
+  const replacements = { branch_id: branchId, start_utc: startUTC, end_utc: endUTC };
+
+  const rows = await sequelize.query(`
+    SELECT
+      p.id         AS product_id,
+      p.name       AS product_name,
+      p.cost_price AS unit_price,
+
+      COALESCE((
+        SELECT SUM(sm0.qty_change)
+        FROM stock_movements sm0
+        WHERE sm0.product_id = p.id
+          AND sm0.branch_id  = :branch_id
+          AND sm0.created_at < :start_utc
+      ), 0) AS inicio,
+
+      COALESCE((
+        SELECT SUM(sm1.qty_change) FROM stock_movements sm1
+        WHERE sm1.product_id = p.id AND sm1.branch_id = :branch_id
+          AND sm1.reference_type = 'purchase'
+          AND sm1.created_at >= :start_utc AND sm1.created_at < :end_utc
+      ), 0) AS compro,
+
+      COALESCE((
+        SELECT SUM(sm2.qty_change) FROM stock_movements sm2
+        WHERE sm2.product_id = p.id AND sm2.branch_id = :branch_id
+          AND sm2.reference_type = 'transfer' AND sm2.qty_change > 0
+          AND sm2.created_at >= :start_utc AND sm2.created_at < :end_utc
+      ), 0) AS recibio,
+
+      COALESCE((
+        SELECT SUM(sm3.qty_change) FROM stock_movements sm3
+        WHERE sm3.product_id = p.id AND sm3.branch_id = :branch_id
+          AND sm3.reference_type = 'adjustment'
+          AND sm3.created_at >= :start_utc AND sm3.created_at < :end_utc
+      ), 0) AS cancelo,
+
+      COALESCE((
+        SELECT ABS(SUM(sm4.qty_change)) FROM stock_movements sm4
+        WHERE sm4.product_id = p.id AND sm4.branch_id = :branch_id
+          AND sm4.reference_type = 'transfer' AND sm4.qty_change < 0
+          AND sm4.created_at >= :start_utc AND sm4.created_at < :end_utc
+      ), 0) AS envio,
+
+      COALESCE((
+        SELECT ABS(SUM(sm5.qty_change)) FROM stock_movements sm5
+        INNER JOIN sales s1 ON s1.id = sm5.reference_id AND s1.deleted_at IS NULL
+        WHERE sm5.product_id = p.id AND sm5.branch_id = :branch_id
+          AND sm5.reference_type = 'sale'
+          AND s1.sales_type = 'Contado'           
+          AND sm5.created_at >= :start_utc AND sm5.created_at < :end_utc
+      ), 0) AS contado,
+
+      COALESCE((
+        SELECT ABS(SUM(sm6.qty_change)) FROM stock_movements sm6
+        INNER JOIN sales s2 ON s2.id = sm6.reference_id AND s2.deleted_at IS NULL
+        WHERE sm6.product_id = p.id AND sm6.branch_id = :branch_id
+          AND sm6.reference_type = 'sale'
+          AND s2.sales_type = 'Credito'           
+          AND sm6.created_at >= :start_utc AND sm6.created_at < :end_utc
+      ), 0) AS credito
+
+    FROM products p
+    WHERE p.deleted_at IS NULL
+      AND p.is_active = 1
+      AND EXISTS (
+        SELECT 1 FROM product_stocks ps
+        WHERE ps.product_id = p.id
+          AND ps.branch_id  = :branch_id
+          AND ps.quantity > 0
+          AND ps.deleted_at IS NULL
+      )
+    ORDER BY p.name
+  `, { replacements, type: sequelize.QueryTypes.SELECT });
+
+  const round = (n) => Math.round(parseFloat(n) * 1000) / 1000;
+
+  return rows.map((row) => {
+    const inicio = round(row.inicio);
+    const compro = round(row.compro);
+    const recibio = round(row.recibio);
+    const cancelo = round(row.cancelo);
+    const envio = round(row.envio);
+    const contado = round(row.contado);
+    const credito = round(row.credito);
+    const unitPrice = round(row.unit_price);
+    const existencia = Math.round((inicio + compro + recibio + cancelo - envio - contado - credito) * 1000) / 1000;
+    const importe = Math.round(unitPrice * existencia * 100) / 100;
+
+    return {
+      productId: row.product_id,
+      productName: row.product_name,
+      inicio,
+      compro,
+      recibio,
+      cancelo,
+      envio,
+      contado,
+      credito,
+      existencia,
+      unitPrice,
+      importe
+    };
+  });
+};
+
+module.exports = { getDailyMovement, getAccountsReceivable, getInventoryReport };

--- a/src/validators/reports.js
+++ b/src/validators/reports.js
@@ -20,4 +20,22 @@ const validateAccountsReceivable = [
   (req, res, next) => validateResults(req, res, next)
 ];
 
-module.exports = { validateDailyMovement, validateAccountsReceivable };
+const validateInventoryReport = [
+  query('branch_id')
+    .notEmpty().withMessage('branch_id es requerido')
+    .isInt({ min: 1 }).withMessage('branch_id debe ser un número entero positivo')
+    .toInt(),
+  query('start_date')
+    .notEmpty().withMessage('start_date es requerida')
+    .isDate({ format: 'YYYY-MM-DD' }).withMessage('start_date debe tener formato YYYY-MM-DD'),
+  query('end_date')
+    .notEmpty().withMessage('end_date es requerida')
+    .isDate({ format: 'YYYY-MM-DD' }).withMessage('end_date debe tener formato YYYY-MM-DD')
+    .custom((endDate, { req }) => {
+      if (endDate < req.query.start_date) throw new Error('end_date debe ser mayor o igual a start_date');
+      return true;
+    }),
+  (req, res, next) => validateResults(req, res, next)
+];
+
+module.exports = { validateDailyMovement, validateAccountsReceivable, validateInventoryReport };


### PR DESCRIPTION
## Summary

- Agrega `GET /reports/inventory` que devuelve movimientos de stock por producto (compras, transferencias recibidas/enviadas, cancelaciones, ventas contado/crédito) para una sucursal y rango de fechas
- Calcula `existencia` e `importe` (precio unitario × existencia) por producto
- Agrega privilegio `view_inventory` / `Ver reporte de inventario` en módulo REPORTS
- El cálculo de fechas usa `Intl.DateTimeFormat` para convertir la fecha local del negocio a UTC sin depender de tablas de timezone en MySQL

## Test plan

- [ ] `GET /reports/inventory?branch_id=1&start_date=2026-01-01&end_date=2026-04-30` con token válido y privilegio `view_inventory` → devuelve array de productos con todos los campos
- [ ] Sin privilegio `view_inventory` → 403
- [ ] `end_date` menor a `start_date` → 400 con mensaje de validación
- [ ] `branch_id` faltante o no entero → 400
- [ ] Verificar que `docs/openapi.json` se regenera correctamente con el nuevo schema `inventoryReportItem`