### PR TITLE
fix(products): change product id collation to utf8mb4_bin

### DIFF
--- a/src/database/migrations/20260506000000-fix-product-id-collation-to-bin.js
+++ b/src/database/migrations/20260506000000-fix-product-id-collation-to-bin.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const CHILD_TABLES = [
+  'campaign_products',
+  'product_prices',
+  'product_stocks',
+  'purchase_details',
+  'sale_details',
+  'stock_movements',
+  'transfer_details'
+];
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS=0');
+    try {
+      await queryInterface.sequelize.query(
+        'ALTER TABLE `products` MODIFY COLUMN `id` VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL'
+      );
+      for (const table of CHILD_TABLES) {
+        await queryInterface.sequelize.query(
+          `ALTER TABLE \`${table}\` MODIFY COLUMN \`product_id\` VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL`
+        );
+      }
+    } finally {
+      await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS=1');
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS=0');
+    try {
+      await queryInterface.sequelize.query(
+        'ALTER TABLE `products` MODIFY COLUMN `id` VARCHAR(20) NOT NULL'
+      );
+      for (const table of CHILD_TABLES) {
+        await queryInterface.sequelize.query(
+          `ALTER TABLE \`${table}\` MODIFY COLUMN \`product_id\` VARCHAR(20) NOT NULL`
+        );
+      }
+    } finally {
+      await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS=1');
+    }
+  }
+};

--- a/src/models/products.js
+++ b/src/models/products.js
@@ -26,7 +26,8 @@ module.exports = (sequelize, DataTypes) => {
     id: {
       type: DataTypes.STRING(20),
       primaryKey: true,
-      allowNull: false
+      allowNull: false,
+      collate: 'utf8mb4_bin'
     },
     barcode: {
       type: DataTypes.STRING(50),


### PR DESCRIPTION
## Summary

- Agrega migración para cambiar la collation de `products.id` y los campos `product_id` de todas las tablas hijas a `utf8mb4_bin`
- Actualiza el modelo Sequelize de `products` para reflejar la nueva collation

## Tablas afectadas por la migración

- `products` (columna `id`)
- `campaign_products`, `product_prices`, `product_stocks`, `purchase_details`, `sale_details`, `stock_movements`, `transfer_details` (columna `product_id`)

## Test plan

- [ ] Ejecutar `npx sequelize-cli db:migrate` y verificar que la migración corre sin errores
- [ ] Verificar que `npx sequelize-cli db:migrate:undo` revierte correctamente
- [ ] Correr suite de tests: `npm test`