### PR TITLE
fix(auth): set sameSite=none for cross-origin cookie support

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -96,8 +96,8 @@ const loginCtrl = async(req, res) => {
     user.set('password', undefined, { strict: false });
     res.cookie('token', token, {
       httpOnly: true,
-      sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'none',
+      secure: true,
       maxAge: 2 * 60 * 60 * 1000
     });
     res.send({ sesion });
@@ -109,8 +109,8 @@ const loginCtrl = async(req, res) => {
 const logoutCtrl = (req, res) => {
   res.clearCookie('token', {
     httpOnly: true,
-    sameSite: 'strict',
-    secure: process.env.NODE_ENV === 'production'
+    sameSite: 'none',
+    secure: true
   });
   res.send({ message: 'Sesión cerrada' });
 };


### PR DESCRIPTION
## Summary

- Cambia `sameSite: 'strict'` → `'none'` en `res.cookie` y `res.clearCookie` del controlador de auth
- Cambia `secure` a `true` (requerido por spec cuando `sameSite=none`)
- Corrige el bug de producción donde el JWT cookie no se enviaba en requests cross-origin (Vercel → Railway)

## Root cause

`SameSite=Strict` hace que los browsers bloqueen el envío de cookies en requests cross-site. En desarrollo funcionaba porque localhost→localhost se trata como same-site, pero en producción el dominio del frontend (Vercel) y el backend (Railway) son distintos.

## Test plan

- [ ] Login en producción y verificar que la cookie `token` llega con `SameSite=None; Secure` en las DevTools → Application → Cookies
- [ ] Verificar que `GET /api/privileges/user/:id` responde 200 después del login
- [ ] Verificar que el logout limpia la cookie correctamente
- [ ] Probar en desarrollo local (requiere HTTPS o usar Bearer header como fallback)