### PR TITLE
fix(sales): lookup product stock by barcode instead of product_id + purch_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Servidor
 PORT=3000
 NODE_ENV=development
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:4173
 
 # Superadmin credentials
 SPADM = superadmin@estelaris.com

--- a/src/constants/sales.js
+++ b/src/constants/sales.js
@@ -55,6 +55,9 @@ const SALES_VALIDATORS = Object.freeze({
   ITEMS_NOT_EXISTS: 'Los artículos son requeridos',
   ITEMS_INVALID: 'Los artículos deben ser un arreglo con al menos un elemento',
 
+  // items.*.bar_code
+  ITEM_BAR_CODE_INVALID: 'El código de barras del lote es requerido y debe tener máximo 100 caracteres',
+
   // items.*.product_id
   ITEM_PRODUCT_ID_INVALID: 'El id de producto es requerido y debe tener máximo 20 caracteres',
 

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -199,13 +199,24 @@ const createSale = async (body, userId) => {
   const branch = await branches.findByPk(branchId, { attributes: ['id', 'ticket_prefix'] });
   if (!branch) return { error: 'BRANCH_NOT_FOUND' };
 
-  // Validar productos
-  const productIds = items.map(i => i.product_id);
+  // Resolver bar_codes a product_id + purch_id y verificar que existan en la sucursal
+  const barCodes = items.map(i => i.bar_code);
+  const stockRefs = await productStocks.findAll({
+    where: { bar_code: barCodes, branch_id: branchId },
+    attributes: ['bar_code', 'product_id', 'purch_id']
+  });
+  if (stockRefs.length !== [...new Set(barCodes)].length) {
+    return { error: 'SOME_PRODUCTS_NOT_FOUND_OR_INACTIVE' };
+  }
+  const stockRefMap = Object.fromEntries(stockRefs.map(s => [s.bar_code, s]));
+
+  // Validar que los productos referenciados estén activos
+  const productIds = [...new Set(stockRefs.map(s => s.product_id))];
   const foundProducts = await products.findAll({
     where: { id: productIds, is_active: true },
     attributes: ['id']
   });
-  if (foundProducts.length !== [...new Set(productIds)].length) {
+  if (foundProducts.length !== productIds.length) {
     return { error: 'SOME_PRODUCTS_NOT_FOUND_OR_INACTIVE' };
   }
 
@@ -222,6 +233,7 @@ const createSale = async (body, userId) => {
   try {
     // Calcular subtotales por línea
     const details = items.map(item => {
+      const { product_id: productId } = stockRefMap[item.bar_code];
       const qty = parseFloat(item.qty);
       const unitPrice = parseFloat(item.unit_price);
       const discount = parseFloat(item.discount || 0);
@@ -229,13 +241,13 @@ const createSale = async (body, userId) => {
       const lineSubtotal = parseFloat((qty * unitPrice * (1 - discount / 100)).toFixed(2));
 
       return {
-        product_id: item.product_id,
+        product_id: productId,
+        bar_code: item.bar_code,
         qty,
         unit_price: unitPrice,
         discount,
         tax_rate: taxRate,
         subtotal: lineSubtotal,
-        purch_id: item.purch_id || null,
         notes: item.notes || null
       };
     });
@@ -294,13 +306,9 @@ const createSale = async (body, userId) => {
     // Validar y decrementar stock
     for (const item of details) {
       const qty = parseFloat(item.qty);
-      const barCode = item.purch_id ? `${item.product_id}-${item.purch_id}` : null;
-      const stockWhere = barCode
-        ? { bar_code: barCode, branch_id: branchId }
-        : { product_id: item.product_id, branch_id: branchId };
 
       const stock = await productStocks.findOne({
-        where: stockWhere,
+        where: { bar_code: item.bar_code, branch_id: branchId },
         transaction,
         lock: transaction.LOCK.UPDATE
       });
@@ -349,8 +357,15 @@ const createSale = async (body, userId) => {
 
     // Crear detalles
     const detailRecords = details.map(d => ({
-      ...d,
       sale_id: sale.id,
+      product_id: d.product_id,
+      purch_id: stockRefMap[d.bar_code].purch_id,
+      qty: d.qty,
+      unit_price: d.unit_price,
+      discount: d.discount,
+      tax_rate: d.tax_rate,
+      subtotal: d.subtotal,
+      notes: d.notes,
       created_at: new Date(),
       updated_at: new Date()
     }));
@@ -506,13 +521,8 @@ const cancelSale = async (id, userId) => {
     // Revertir stock
     for (const detail of sale.details) {
       const qty = parseFloat(detail.qty);
-      const barCode = detail.purch_id ? `${detail.product_id}-${detail.purch_id}` : null;
-      const stockWhere = barCode
-        ? { bar_code: barCode, branch_id: sale.branch_id }
-        : { product_id: detail.product_id, branch_id: sale.branch_id };
-
       const stock = await productStocks.findOne({
-        where: stockWhere,
+        where: { bar_code: `${detail.product_id}-${detail.purch_id}`, branch_id: sale.branch_id },
         transaction,
         lock: transaction.LOCK.UPDATE
       });

--- a/src/tests/23_sales.test.js
+++ b/src/tests/23_sales.test.js
@@ -22,6 +22,7 @@ let creditoSaleId = null;
 let cancelSaleId = null;
 let customerId = null;
 let addressId = null;
+let purchaseId = null;
 
 const api = request(server.app);
 
@@ -101,7 +102,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
       .send(purchaseForSaleStock)
       .expect(200);
 
-    const purchaseId = purchRes.body.purchase.id;
+    purchaseId = purchRes.body.purchase.id;
 
     await api
       .patch(`/api/purchases/${purchaseId}/receive`)
@@ -119,7 +120,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateContado(customerId, addressId))
+        .send(saleCreateContado(customerId, addressId, purchaseId))
         .expect(200);
 
       expect(response.body).toHaveProperty('sale');
@@ -137,7 +138,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId))
+        .send(saleCreateCredito(customerId, addressId, purchaseId))
         .expect(200);
 
       expect(response.body).toHaveProperty('sale');
@@ -212,7 +213,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateEntregado(customerId, addressId))
+        .send(saleCreateEntregado(customerId, addressId, purchaseId))
         .expect(200);
 
       expect(response.body.sale.delivery_status).toBe('Entregado');
@@ -223,7 +224,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateContado(customerId, addressId))
+        .send(saleCreateContado(customerId, addressId, purchaseId))
         .expect(200);
 
       expect(response.body.sale.delivery_status).toBe('Pendiente');
@@ -232,7 +233,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
     test('10. Crear venta sin token. Expect 401', async () => {
       await api
         .post('/api/sales')
-        .send(saleCreateContado(customerId, addressId))
+        .send(saleCreateContado(customerId, addressId, purchaseId))
         .expect(401);
     });
   });
@@ -339,7 +340,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId))
+        .send(saleCreateCredito(customerId, addressId, purchaseId))
         .expect(200);
 
       cancelSaleId = newSaleRes.body.sale.id;
@@ -363,7 +364,7 @@ describe('[SALES] Test api sales /api/sales/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId))
+        .send(saleCreateCredito(customerId, addressId, purchaseId))
         .expect(200);
 
       const deleteSaleId = newSaleRes.body.sale.id;

--- a/src/tests/24_sale_payments.test.js
+++ b/src/tests/24_sale_payments.test.js
@@ -19,6 +19,7 @@ let createdPaymentId = null;
 let fullPaymentSaleId = null;
 let customerId = null;
 let addressId = null;
+let purchaseId = null;
 
 const api = request(server.app);
 
@@ -91,8 +92,10 @@ describe('[SALE_PAYMENTS] Test api sale-payments /api/sale-payments/', () => {
       .send(purchaseForSaleStock)
       .expect(200);
 
+    purchaseId = purchRes.body.purchase.id;
+
     await api
-      .patch(`/api/purchases/${purchRes.body.purchase.id}/receive`)
+      .patch(`/api/purchases/${purchaseId}/receive`)
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
       .expect(200);
@@ -102,7 +105,7 @@ describe('[SALE_PAYMENTS] Test api sale-payments /api/sale-payments/', () => {
       .post('/api/sales')
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
-      .send(saleCreateCredito(customerId, addressId))
+      .send(saleCreateCredito(customerId, addressId, purchaseId))
       .expect(200);
 
     creditoSaleId = saleRes.body.sale.id;
@@ -112,7 +115,7 @@ describe('[SALE_PAYMENTS] Test api sale-payments /api/sale-payments/', () => {
       .post('/api/sales')
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
-      .send(saleCreateCredito(customerId, addressId))
+      .send(saleCreateCredito(customerId, addressId, purchaseId))
       .expect(200);
 
     cancelledSaleId = cancelRes.body.sale.id;
@@ -155,7 +158,7 @@ describe('[SALE_PAYMENTS] Test api sale-payments /api/sale-payments/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId))
+        .send(saleCreateCredito(customerId, addressId, purchaseId))
         .expect(200);
 
       fullPaymentSaleId = newSaleRes.body.sale.id;
@@ -272,7 +275,7 @@ describe('[SALE_PAYMENTS] Test api sale-payments /api/sale-payments/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId))
+        .send(saleCreateCredito(customerId, addressId, purchaseId))
         .expect(200);
 
       const response = await api

--- a/src/tests/25_sale_deliveries.test.js
+++ b/src/tests/25_sale_deliveries.test.js
@@ -16,6 +16,7 @@ let deliveryId = null;
 let fullFlowDeliveryId = null;
 let customerId = null;
 let addressId = null;
+let purchaseId = null;
 
 const api = request(server.app);
 
@@ -90,8 +91,10 @@ describe('[SALE_DELIVERIES] Test api sale-deliveries /api/sale-deliveries/', () 
       .send(purchaseForSaleStock)
       .expect(200);
 
+    purchaseId = purchRes.body.purchase.id;
+
     await api
-      .patch(`/api/purchases/${purchRes.body.purchase.id}/receive`)
+      .patch(`/api/purchases/${purchaseId}/receive`)
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
       .expect(200);
@@ -101,7 +104,7 @@ describe('[SALE_DELIVERIES] Test api sale-deliveries /api/sale-deliveries/', () 
       .post('/api/sales')
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
-      .send(saleCreateCredito(customerId, addressId))
+      .send(saleCreateCredito(customerId, addressId, purchaseId))
       .expect(200);
 
     saleId = saleRes.body.sale.id;

--- a/src/tests/34_loyalty_points.test.js
+++ b/src/tests/34_loyalty_points.test.js
@@ -15,6 +15,7 @@ let configId = null;
 let customerId = null;
 let addressId = null;
 let saleWithPointsId = null;
+let purchaseId = null;
 
 // ─── Fixture helpers ───────────────────────────────────────────────────────────
 
@@ -69,7 +70,7 @@ const loyaltyPurchaseStock = {
   ]
 };
 
-const saleContadoForPoints = (cId, aId) => ({
+const saleContadoForPoints = (cId, aId, purchId) => ({
   branch_id: 1,
   customer_id: cId,
   customer_address_id: aId,
@@ -77,12 +78,12 @@ const saleContadoForPoints = (cId, aId) => ({
   sales_date: '2026-03-31',
   sales_type: 'Contado',
   items: [
-    { product_id: 'TEST-001', qty: 5, unit_price: 100.00, discount: 0, tax_rate: 0 }
+    { bar_code: `TEST-001-${purchId}`, qty: 5, unit_price: 100.00, discount: 0, tax_rate: 0 }
   ]
   // subtotal=500, tax=0, total=500 → points = floor(500 * 0.1) = 50
 });
 
-const saleContadoForRedeem = (cId, aId, pointsToRedeem) => ({
+const saleContadoForRedeem = (cId, aId, purchId, pointsToRedeem) => ({
   branch_id: 1,
   customer_id: cId,
   customer_address_id: aId,
@@ -91,7 +92,7 @@ const saleContadoForRedeem = (cId, aId, pointsToRedeem) => ({
   sales_type: 'Contado',
   points_redeemed: pointsToRedeem,
   items: [
-    { product_id: 'TEST-001', qty: 10, unit_price: 100.00, discount: 0, tax_rate: 0 }
+    { bar_code: `TEST-001-${purchId}`, qty: 10, unit_price: 100.00, discount: 0, tax_rate: 0 }
   ]
   // subtotal=1000, total=1000
   // redeeming 20 pts → discount = 20 * 0.10 = $2
@@ -184,8 +185,10 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
       .send(loyaltyPurchaseStock)
       .expect(200);
 
+    purchaseId = purchRes.body.purchase.id;
+
     await api
-      .patch(`/api/purchases/${purchRes.body.purchase.id}/receive`)
+      .patch(`/api/purchases/${purchaseId}/receive`)
       .auth(Token, { type: 'bearer' })
       .set('x-branch-id', '1')
       .expect(200);
@@ -308,7 +311,7 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleContadoForPoints(customerId, addressId))
+        .send(saleContadoForPoints(customerId, addressId, purchaseId))
         .expect(200);
 
       expect(response.body).toHaveProperty('sale');
@@ -357,7 +360,7 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleContadoForRedeem(customerId, addressId, 20))
+        .send(saleContadoForRedeem(customerId, addressId, purchaseId, 20))
         .expect(200);
 
       expect(response.body).toHaveProperty('sale');
@@ -395,7 +398,7 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleContadoForRedeem(customerId, addressId, 99999))
+        .send(saleContadoForRedeem(customerId, addressId, purchaseId, 99999))
         .expect(422);
     });
 
@@ -404,7 +407,7 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleContadoForRedeem(customerId, addressId, 3))
+        .send(saleContadoForRedeem(customerId, addressId, purchaseId, 3))
         .expect(422);
     });
 
@@ -420,7 +423,7 @@ describe('[LOYALTY POINTS] Test api loyalty /api/loyaltyPoints/', () => {
         sales_date: '2026-03-31',
         sales_type: 'Contado',
         points_redeemed: 600, // 600 * $0.10 = $60 > 50% de $100 ($50)
-        items: [{ product_id: 'TEST-001', qty: 1, unit_price: 100.00, discount: 0, tax_rate: 0 }]
+        items: [{ bar_code: `TEST-001-${purchaseId}`, qty: 1, unit_price: 100.00, discount: 0, tax_rate: 0 }]
       };
       await api
         .post('/api/sales')

--- a/src/tests/helper/salesData.js
+++ b/src/tests/helper/salesData.js
@@ -35,7 +35,7 @@ const purchaseForSaleStock = {
   ]
 };
 
-const saleCreateContado = (customerId, addressId) => ({
+const saleCreateContado = (customerId, addressId, purchaseId) => ({
   branch_id: 1,
   customer_id: customerId,
   customer_address_id: addressId,
@@ -43,11 +43,11 @@ const saleCreateContado = (customerId, addressId) => ({
   sales_date: '2026-03-04',
   sales_type: 'Contado',
   items: [
-    { product_id: 'TEST-001', qty: 2, unit_price: 150.00, discount: 0, tax_rate: 16 }
+    { bar_code: `TEST-001-${purchaseId}`, qty: 2, unit_price: 150.00, discount: 0, tax_rate: 16 }
   ]
 });
 
-const saleCreateCredito = (customerId, addressId) => ({
+const saleCreateCredito = (customerId, addressId, purchaseId) => ({
   branch_id: 1,
   customer_id: customerId,
   customer_address_id: addressId,
@@ -58,8 +58,8 @@ const saleCreateCredito = (customerId, addressId) => ({
   total_days_term: 60,
   notes: 'Venta a crédito de prueba',
   items: [
-    { product_id: 'TEST-001', qty: 3, unit_price: 200.00, discount: 5, tax_rate: 16 },
-    { product_id: 'TEST-002', qty: 2, unit_price: 100.00, discount: 0, tax_rate: 16 }
+    { bar_code: `TEST-001-${purchaseId}`, qty: 3, unit_price: 200.00, discount: 5, tax_rate: 16 },
+    { bar_code: `TEST-002-${purchaseId}`, qty: 2, unit_price: 100.00, discount: 0, tax_rate: 16 }
   ]
 });
 
@@ -68,7 +68,7 @@ const saleCreateNoCustomer = {
   customer_address_id: 1,
   employee_id: 1,
   sales_date: '2026-03-04',
-  items: [{ product_id: 'TEST-001', qty: 1, unit_price: 100.00 }]
+  items: [{ bar_code: 'TEST-001-1', qty: 1, unit_price: 100.00 }]
 };
 
 const saleCreateNoAddress = {
@@ -76,7 +76,7 @@ const saleCreateNoAddress = {
   customer_id: 1,
   employee_id: 1,
   sales_date: '2026-03-04',
-  items: [{ product_id: 'TEST-001', qty: 1, unit_price: 100.00 }]
+  items: [{ bar_code: 'TEST-001-1', qty: 1, unit_price: 100.00 }]
 };
 
 const saleCreateNoEmployee = {
@@ -84,7 +84,7 @@ const saleCreateNoEmployee = {
   customer_id: 1,
   customer_address_id: 1,
   sales_date: '2026-03-04',
-  items: [{ product_id: 'TEST-001', qty: 1, unit_price: 100.00 }]
+  items: [{ bar_code: 'TEST-001-1', qty: 1, unit_price: 100.00 }]
 };
 
 const saleCreateNoDate = {
@@ -92,7 +92,7 @@ const saleCreateNoDate = {
   customer_id: 1,
   customer_address_id: 1,
   employee_id: 1,
-  items: [{ product_id: 'TEST-001', qty: 1, unit_price: 100.00 }]
+  items: [{ bar_code: 'TEST-001-1', qty: 1, unit_price: 100.00 }]
 };
 
 const saleCreateNoItems = {
@@ -103,7 +103,7 @@ const saleCreateNoItems = {
   sales_date: '2026-03-04'
 };
 
-const saleCreateEntregado = (customerId, addressId) => ({
+const saleCreateEntregado = (customerId, addressId, purchaseId) => ({
   branch_id: 1,
   customer_id: customerId,
   customer_address_id: addressId,
@@ -112,7 +112,7 @@ const saleCreateEntregado = (customerId, addressId) => ({
   sales_type: 'Contado',
   delivery_status: 'Entregado',
   items: [
-    { product_id: 'TEST-001', qty: 1, unit_price: 150.00, discount: 0, tax_rate: 16 }
+    { bar_code: `TEST-001-${purchaseId}`, qty: 1, unit_price: 150.00, discount: 0, tax_rate: 16 }
   ]
 });
 

--- a/src/validators/sales.js
+++ b/src/validators/sales.js
@@ -90,10 +90,11 @@ const valiAddRecord = [
   check('items')
     .exists().withMessage(SALES_VALIDATORS.ITEMS_NOT_EXISTS).bail()
     .isArray({ min: 1 }).withMessage(SALES_VALIDATORS.ITEMS_INVALID).bail(),
-  check('items.*.product_id')
-    .isString().withMessage(SALES_VALIDATORS.ITEM_PRODUCT_ID_INVALID).bail()
-    .notEmpty().withMessage(SALES_VALIDATORS.ITEM_PRODUCT_ID_INVALID).bail()
-    .isLength({ max: 20 }).withMessage(SALES_VALIDATORS.ITEM_PRODUCT_ID_INVALID).bail(),
+  check('items.*.bar_code')
+    .exists().withMessage(SALES_VALIDATORS.ITEM_BAR_CODE_INVALID).bail()
+    .notEmpty().withMessage(SALES_VALIDATORS.ITEM_BAR_CODE_INVALID).bail()
+    .isString().withMessage(SALES_VALIDATORS.ITEM_BAR_CODE_INVALID).bail()
+    .isLength({ max: 100 }).withMessage(SALES_VALIDATORS.ITEM_BAR_CODE_INVALID).bail(),
   check('items.*.qty')
     .isDecimal({ decimal_digits: '0,3', force_decimal: false }).withMessage(SALES_VALIDATORS.ITEM_QTY_INVALID).bail()
     .custom(val => parseFloat(val) > 0).withMessage(SALES_VALIDATORS.ITEM_QTY_INVALID),
@@ -107,10 +108,6 @@ const valiAddRecord = [
   check('items.*.tax_rate')
     .optional()
     .isDecimal({ decimal_digits: '0,2', force_decimal: false }).withMessage(SALES_VALIDATORS.ITEM_TAX_RATE_INVALID),
-  check('items.*.purch_id')
-    .optional({ nullable: true })
-    .isInt().withMessage(SALES_VALIDATORS.ITEM_PURCH_ID_INVALID).bail()
-    .toInt(),
   check('items.*.notes')
     .optional({ nullable: true })
     .isString().withMessage(SALES_VALIDATORS.ITEM_NOTES_INVALID).bail(),


### PR DESCRIPTION
## Summary

El endpoint `POST /api/sales` cambió su contrato para resolver un bug crítico en la identificación de stock cuando un producto tiene múltiples lotes en la misma sucursal.

**Problema anterior:** Usar `product_id` + `purch_id` con `findOne({ product_id, branch_id })` retornaba el primer registro por clave primaria, que podía tener cantidad 0 en lugar del lote correcto con stock disponible.

**Solución:** El frontend ahora envía `bar_code` por item (ej. `SAL-001-1`). Este código junto con `branch_id` identifica unívocamente el registro de stock correcto, ya que `bar_code` se genera como `{product_id}-{purch_id}` al recibir una compra.

## Cambios principales

- **`src/validators/sales.js`** — `items.*.bar_code` requerido; reemplaza `product_id` + `purch_id`
- **`src/services/sales.js`** — Lookup de stock por `bar_code + branch_id`; `purch_id` en `saleDetails` extraído del `stockRefMap` pre-transacción
- **`src/constants/sales.js`** — Constante de error `ITEM_BAR_CODE_INVALID`
- **Tests actualizados** — `23`, `24`, `25`, `34` y helper `salesData.js` actualizados para propagar `purchaseId`
- **`.env.example`** — `FRONTEND_URL` port actualizado a 4173 para alineación con dev

## Test plan

- [x] Suite completa de tests pasa: 1312/1312
- [x] `npm test` valida validadores con `bar_code` requerido
- [x] `npm test -- --testPathPattern="23"` verifica creación de ventas con barcode
- [x] `npm test -- --testPathPattern="24"` verifica pagos de ventas
- [x] `npm test -- --testPathPattern="25"` verifica entregas de ventas
- [x] `npm test -- --testPathPattern="34"` verifica puntos de lealtad
- [x] Helper `salesData.js` propaga correctamente `purchaseId` para generar barcodes dinámicos