### PR TITLE
feat(sales): add sorting support to sales endpoints

### DIFF
--- a/src/constants/sales.js
+++ b/src/constants/sales.js
@@ -94,4 +94,6 @@ const TICKET_CONFIG = Object.freeze({
   PREFIX_FALLBACK_PADDING: 3
 });
 
-module.exports = { SALES_VALIDATORS, TICKET_CONFIG };
+const SORT_WHITELIST = Object.freeze(['id', 'sales_date', 'sales_total', 'status']);
+
+module.exports = { SALES_VALIDATORS, TICKET_CONFIG, SORT_WHITELIST };

--- a/src/controllers/sales.js
+++ b/src/controllers/sales.js
@@ -19,7 +19,7 @@ const getRecords = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { sales, total } = await getAllSales(req.branchId, page, limit, search);
+    const { sales, total } = await getAllSales(req.branchId, page, limit, search, data.sortBy, data.sortOrder);
     res.send(buildPaginationResponse('sales', sales, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS -> ${error}`);
@@ -59,7 +59,7 @@ const getRecordsByBranch = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { sales, total } = await getSalesByBranch(data.branch_id, page, limit, search);
+    const { sales, total } = await getSalesByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder);
     res.send(buildPaginationResponse('sales', sales, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_BRANCH -> ${error}`, 400);

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -6,7 +6,7 @@ const {
 const { sequelize } = require('../models/index');
 const { Op } = require('sequelize');
 const accountingEngine = require('./accountingEngine.service');
-const { TICKET_CONFIG } = require('../constants/sales');
+const { TICKET_CONFIG, SORT_WHITELIST } = require('../constants/sales');
 const {
   getActiveConfig,
   getOrCreateCustomerPoints,
@@ -71,15 +71,21 @@ const saleIncludes = [
 
 const PERIOD_DAYS = { Semanal: 7, Quincenal: 15, Mensual: 30 };
 
-const getAllSales = async (branchId, page = 1, limit = 20, search = '') => {
+const sanitizeSort = (sortBy, sortOrder) => ({
+  safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
+  safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
+});
+
+const getAllSales = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = branchId ? { branch_id: branchId } : {};
   if (search) where.ticket = { [Op.like]: `%${search}%` };
   const { count, rows } = await sales.findAndCountAll({
     attributes: saleAttributes,
     where,
     include: saleIncludes,
-    order: [['sales_date', 'DESC']],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true
@@ -111,15 +117,16 @@ const getSalesByCustomer = async (customerId, page = 1, limit = 20, search = '')
   return { sales: rows, total: count };
 };
 
-const getSalesByBranch = async (branchId, page = 1, limit = 20, search = '') => {
+const getSalesByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { branch_id: branchId };
   if (search) where.ticket = { [Op.like]: `%${search}%` };
   const { count, rows } = await sales.findAndCountAll({
     attributes: saleAttributes,
     where,
     include: saleIncludes,
-    order: [['sales_date', 'DESC']],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true

--- a/src/tests/23_sales.test.js
+++ b/src/tests/23_sales.test.js
@@ -314,6 +314,124 @@ describe('[SALES] Test api sales /api/sales/', () => {
   });
 
   // ============================================
+  // GET /api/sales — ordenamiento
+  // ============================================
+  describe('GET /api/sales - sorting', () => {
+    test('20. Sin params de orden → 200, respuesta tiene sales y pagination', async () => {
+      const response = await api
+        .get('/api/sales')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+      expect(response.body).toHaveProperty('pagination');
+      expect(Array.isArray(response.body.sales)).toBe(true);
+    });
+
+    test('21. ?sortBy=sales_date&sortOrder=ASC → 200', async () => {
+      const response = await api
+        .get('/api/sales?sortBy=sales_date&sortOrder=ASC')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+      expect(Array.isArray(response.body.sales)).toBe(true);
+    });
+
+    test('22. ?sortBy=sales_total&sortOrder=DESC → 200', async () => {
+      const response = await api
+        .get('/api/sales?sortBy=sales_total&sortOrder=DESC')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+    });
+
+    test('23. ?sortBy=status → 200', async () => {
+      const response = await api
+        .get('/api/sales?sortBy=status')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+    });
+
+    test('24. ?sortBy=invalid_column → 400 (validator rechaza)', async () => {
+      await api
+        .get('/api/sales?sortBy=invalid_column')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(400);
+    });
+
+    test('25. ?sortOrder=RANDOM → 400 (validator rechaza)', async () => {
+      await api
+        .get('/api/sales?sortOrder=RANDOM')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(400);
+    });
+
+    test('26. ?sortBy=id&sortOrder=ASC combinado con search → 200', async () => {
+      const response = await api
+        .get('/api/sales?sortBy=id&sortOrder=ASC&search=test')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+      expect(response.body).toHaveProperty('pagination');
+    });
+  });
+
+  // ============================================
+  // GET /api/sales/branch/:branchId — ordenamiento
+  // ============================================
+  describe('GET /api/sales/branch/:branchId - sorting', () => {
+    test('27. ?sortBy=sales_date&sortOrder=ASC → 200', async () => {
+      const response = await api
+        .get('/api/sales/branch/1?sortBy=sales_date&sortOrder=ASC')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+      expect(response.body).toHaveProperty('pagination');
+      expect(Array.isArray(response.body.sales)).toBe(true);
+    });
+
+    test('28. ?sortBy=sales_total&sortOrder=ASC → 200', async () => {
+      const response = await api
+        .get('/api/sales/branch/1?sortBy=sales_total&sortOrder=ASC')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('sales');
+    });
+
+    test('29. ?sortBy=invalid_column → 400 (validator rechaza)', async () => {
+      await api
+        .get('/api/sales/branch/1?sortBy=invalid_column')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(400);
+    });
+
+    test('30. ?sortOrder=asc (minúsculas) → 400 (validator rechaza)', async () => {
+      await api
+        .get('/api/sales/branch/1?sortOrder=asc')
+        .auth(Token, { type: 'bearer' })
+        .set('x-branch-id', '1')
+        .expect(400);
+    });
+  });
+
+  // ============================================
   // PUT /api/sales/:id
   // ============================================
   describe('PUT /api/sales/:id', () => {

--- a/src/tests/unit/sales.service.test.js
+++ b/src/tests/unit/sales.service.test.js
@@ -1,0 +1,182 @@
+const { sales } = require('../../models/index');
+const { getAllSales, getSalesByBranch } = require('../../services/sales');
+
+jest.mock('../../models/index', () => ({
+  sales: { findAndCountAll: jest.fn(), findOne: jest.fn(), create: jest.fn(), destroy: jest.fn() },
+  saleDetails: { bulkCreate: jest.fn() },
+  saleInstallments: { bulkCreate: jest.fn(), destroy: jest.fn() },
+  salePayments: { create: jest.fn(), count: jest.fn() },
+  saleDeliveries: {},
+  customers: { findByPk: jest.fn() },
+  customerAddresses: { findOne: jest.fn() },
+  employees: { findByPk: jest.fn() },
+  branches: { findByPk: jest.fn() },
+  users: {},
+  products: { findAll: jest.fn() },
+  productStocks: { findAll: jest.fn(), findOne: jest.fn() },
+  stockMovements: { create: jest.fn() },
+  sequelize: { transaction: jest.fn() }
+}));
+
+jest.mock('../../services/accountingEngine.service', () => ({
+  generateFromSale: jest.fn().mockResolvedValue(null),
+  generateFromSalePayment: jest.fn().mockResolvedValue(null)
+}));
+
+jest.mock('../../services/loyaltyPoints', () => ({
+  getActiveConfig: jest.fn().mockResolvedValue(null),
+  getOrCreateCustomerPoints: jest.fn(),
+  calculateEarnedPoints: jest.fn(),
+  validateRedeem: jest.fn(),
+  redeemPoints: jest.fn(),
+  earnPoints: jest.fn(),
+  voidRedeemPoints: jest.fn(),
+  voidEarnPoints: jest.fn()
+}));
+
+const mockResult = { count: 0, rows: [] };
+
+describe('Sales Service - Sorting (unit)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sales.findAndCountAll.mockResolvedValue(mockResult);
+  });
+
+  // ============================================================
+  // getAllSales
+  // ============================================================
+  describe('getAllSales', () => {
+    test('default: sin params ordena por id DESC', async () => {
+      await getAllSales();
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['id', 'DESC']] })
+      );
+    });
+
+    test('sortBy=sales_date, sortOrder=ASC', async () => {
+      await getAllSales(null, 1, 20, '', 'sales_date', 'ASC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['sales_date', 'ASC']] })
+      );
+    });
+
+    test('sortBy=sales_total, sortOrder=DESC', async () => {
+      await getAllSales(null, 1, 20, '', 'sales_total', 'DESC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['sales_total', 'DESC']] })
+      );
+    });
+
+    test('sortBy=status usa sortOrder default DESC', async () => {
+      await getAllSales(null, 1, 20, '', 'status');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['status', 'DESC']] })
+      );
+    });
+
+    test('sortBy inválido hace fallback a id', async () => {
+      await getAllSales(null, 1, 20, '', '; DROP TABLE sales; --', 'ASC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['id', 'ASC']] })
+      );
+    });
+
+    test('sortOrder inválido hace fallback a DESC', async () => {
+      await getAllSales(null, 1, 20, '', 'sales_date', 'RANDOM');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['sales_date', 'DESC']] })
+      );
+    });
+
+    test('ambos params inválidos → id DESC', async () => {
+      await getAllSales(null, 1, 20, '', 'invalid_col', 'INVALID_ORDER');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['id', 'DESC']] })
+      );
+    });
+
+    test('retorna { sales, total } con la forma correcta', async () => {
+      const rows = [{ id: 1 }, { id: 2 }];
+      sales.findAndCountAll.mockResolvedValue({ count: 2, rows });
+
+      const result = await getAllSales();
+
+      expect(result.sales).toEqual(rows);
+      expect(result.total).toBe(2);
+    });
+
+    test('filtra por branchId en el where', async () => {
+      await getAllSales(3, 1, 20, '', 'id', 'ASC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ branch_id: 3 }) })
+      );
+    });
+
+    test('pagination: offset calculado correctamente', async () => {
+      await getAllSales(null, 3, 10, '');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10, offset: 20 })
+      );
+    });
+  });
+
+  // ============================================================
+  // getSalesByBranch
+  // ============================================================
+  describe('getSalesByBranch', () => {
+    test('default: sin params ordena por id DESC', async () => {
+      await getSalesByBranch(1);
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['id', 'DESC']] })
+      );
+    });
+
+    test('sortBy=sales_date, sortOrder=ASC', async () => {
+      await getSalesByBranch(1, 1, 20, '', 'sales_date', 'ASC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['sales_date', 'ASC']] })
+      );
+    });
+
+    test('sortBy inválido hace fallback a id', async () => {
+      await getSalesByBranch(1, 1, 20, '', 'created_by; --', 'DESC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['id', 'DESC']] })
+      );
+    });
+
+    test('sortOrder inválido hace fallback a DESC', async () => {
+      await getSalesByBranch(1, 1, 20, '', 'sales_total', 'asc');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ order: [['sales_total', 'DESC']] })
+      );
+    });
+
+    test('siempre filtra por branch_id', async () => {
+      await getSalesByBranch(5, 1, 20, '', 'id', 'ASC');
+
+      expect(sales.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { branch_id: 5 } })
+      );
+    });
+
+    test('propaga error de BD', async () => {
+      sales.findAndCountAll.mockRejectedValue(new Error('DB error'));
+
+      await expect(getSalesByBranch(1)).rejects.toThrow('DB error');
+    });
+  });
+});

--- a/src/validators/sales.js
+++ b/src/validators/sales.js
@@ -1,11 +1,12 @@
 const { check } = require('express-validator');
 const validateResults = require('../utils/handleValidator');
-const { SALES_VALIDATORS } = require('../constants/sales');
-const { paginationChecks } = require('./shared');
+const { SALES_VALIDATORS, SORT_WHITELIST } = require('../constants/sales');
+const { paginationChecks, sortChecks } = require('./shared');
 
 const validateGetAll = [
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  ...sortChecks(SORT_WHITELIST),
   (req, res, next) => validateResults(req, res, next)
 ];
 
@@ -34,6 +35,7 @@ const validateGetByBranch = [
     .isInt().withMessage(SALES_VALIDATORS.BRANCH_ID_INVALID).bail(),
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  ...sortChecks(SORT_WHITELIST),
   (req, res, next) => validateResults(req, res, next)
 ];
 

--- a/src/validators/shared.js
+++ b/src/validators/shared.js
@@ -5,4 +5,9 @@ const paginationChecks = [
   check('limit').optional().isInt({ min: 1, max: 100 }).withMessage('limit debe ser un entero entre 1 y 100')
 ];
 
-module.exports = { paginationChecks };
+const sortChecks = (whitelist) => [
+  check('sortBy').optional().isString().trim().isIn(whitelist),
+  check('sortOrder').optional().isString().trim().isIn(['ASC', 'DESC'])
+];
+
+module.exports = { paginationChecks, sortChecks };


### PR DESCRIPTION
## Summary

Add sorting support to GET /api/sales and GET /api/sales/branch/:branchId endpoints, allowing clients to sort by multiple fields in ascending or descending order.

- New query params: `sortBy` (id | sales_date | sales_total | status, default: id) and `sortOrder` (ASC | DESC, default: DESC)
- Invalid values rejected by validator with 400 error
- Service-level sanitizeSort() provides defense-in-depth against SQL injection via ORDER BY
- SORT_WHITELIST extracted to constants/sales.js as single source of truth
- sortChecks() reusable helper added to validators/shared.js (same pattern as paginationChecks)

## Changes

- `src/constants/sales.js` — Add SORT_WHITELIST constant
- `src/validators/shared.js` — Add reusable sortChecks() validation helper
- `src/validators/sales.js` — Integrate sortChecks into validateGetAll and validateGetByBranch
- `src/controllers/sales.js` — Pass sortBy/sortOrder from query to service layer
- `src/services/sales.js` — Add sanitizeSort() helper and integrate into getAllSales/getSalesByBranch
- `src/tests/unit/sales.service.test.js` — 16 unit tests for sanitizeSort and service sorting
- `src/tests/23_sales.test.js` — 11 integration tests for valid/invalid sort param combinations

## Test Coverage

- Unit tests: sanitizeSort() edge cases, injection attempts, whitelist enforcement
- Integration tests: valid sort combinations, invalid values (400), parameter precedence
- All 27 new tests passing

## Security

sortChecks() validates at API level; sanitizeSort() provides second layer of protection against SQL injection by whitelist-matching the final ORDER BY clause before passing to Sequelize.