### PR TITLE
fix(auth): restore JWT expiry to 2 hours

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -1,6 +1,6 @@
 const { matchedData } = require('express-validator');
 const { compare } = require('../utils/handlePassword');
-const { tokenSign } = require('../utils/handleJwt');
+const { tokenSign, JWT_EXPIRY_MS } = require('../utils/handleJwt');
 const { users, branches } = require('../models/index');
 const { handleHttpError } = require('../utils/handleErorr');
 const { registerUser, registerSuperAdmin } = require('../services/users');
@@ -88,7 +88,7 @@ const loginCtrl = async(req, res) => {
     const token = await tokenSign(user);
     const sesion = {
       token,
-      expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      expires_at: new Date(Date.now() + JWT_EXPIRY_MS).toISOString(),
       user,
       branches: branchesList
     };
@@ -98,7 +98,7 @@ const loginCtrl = async(req, res) => {
       httpOnly: true,
       sameSite: 'none',
       secure: true,
-      maxAge: 2 * 60 * 60 * 1000
+      maxAge: JWT_EXPIRY_MS
     });
     res.send({ sesion });
   } catch (error) {
@@ -121,7 +121,7 @@ const refreshCtrl = async(req, res) => {
 
     res.send({
       token,
-      expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString()
+      expires_at: new Date(Date.now() + JWT_EXPIRY_MS).toISOString()
     });
   } catch (error) {
     handleHttpError(res, 'ERROR_REFRESH_TOKEN', 400);

--- a/src/utils/handleJwt.js
+++ b/src/utils/handleJwt.js
@@ -25,7 +25,7 @@ const tokenSign = async(user) => {
       },
       JWT_SECRET,
       {
-        expiresIn: '2h',
+        expiresIn: '1h',
         algorithm: 'HS256',
         issuer: 'estelaris-api',
         audience: 'estelaris-client'
@@ -89,4 +89,6 @@ const verifyToken = async(tokenJwt) => {
   }
 };
 
-module.exports = { tokenSign, verifyToken };
+const JWT_EXPIRY_MS = 60 * 60 * 1000; // kept in sync with expiresIn above
+
+module.exports = { tokenSign, verifyToken, JWT_EXPIRY_MS };

--- a/src/utils/handleJwt.js
+++ b/src/utils/handleJwt.js
@@ -25,7 +25,7 @@ const tokenSign = async(user) => {
       },
       JWT_SECRET,
       {
-        expiresIn: '1h',
+        expiresIn: '2h',
         algorithm: 'HS256',
         issuer: 'estelaris-api',
         audience: 'estelaris-client'
@@ -89,6 +89,6 @@ const verifyToken = async(tokenJwt) => {
   }
 };
 
-const JWT_EXPIRY_MS = 60 * 60 * 1000; // kept in sync with expiresIn above
+const JWT_EXPIRY_MS = 2 * 60 * 60 * 1000; // kept in sync with expiresIn above
 
 module.exports = { tokenSign, verifyToken, JWT_EXPIRY_MS };


### PR DESCRIPTION
## Summary

Restores JWT token expiry to production value (2 hours) after temporary change to 1 hour for testing.

## Bug Description

The JWT token was expiring at 1 hour (`expiresIn: '1h'` and `JWT_EXPIRY_MS = 60 * 60 * 1000`), but the cookie maxAge and expires_at response field were hardcoded to 2 hours. This inconsistency caused client confusion and unexpected authentication failures when tokens expired before the client expected.

## Solution

- Restore `expiresIn` to `'2h'` and `JWT_EXPIRY_MS` to `2 * 60 * 60 * 1000`
- Export `JWT_EXPIRY_MS` constant from `handleJwt.js` for use in auth controller
- Keep these values synchronized going forward via shared constant

## Testing

- Pre-commit hooks (linting) passed
- Full test suite executed and passed