### PR TITLE
fix(auth): rotate HttpOnly cookie on token refresh

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -119,7 +119,14 @@ const refreshCtrl = async(req, res) => {
     const user = req.user;
     const token = await tokenSign(user);
 
-    res.send({
+    res.cookie('token', token, {
+      httpOnly: true,
+      sameSite: 'none',
+      secure: true,
+      maxAge: JWT_EXPIRY_MS,
+      path: '/'
+    });
+    res.json({
       token,
       expires_at: new Date(Date.now() + JWT_EXPIRY_MS).toISOString()
     });


### PR DESCRIPTION
## Summary

**Bug:** POST /api/auth/refresh returned a new JWT token in the response body but never sent a Set-Cookie header to update the HttpOnly refresh token. This left the cookie stale and expiring at the original time, causing 401 errors after the token's actual expiry time passed. The frontend received the new token in the body and updated localStorage, creating the illusion of a successful refresh, but subsequent requests failed when the stale cookie was sent alongside the updated token.

**Fix:** Added `res.cookie()` call in the refresh controller to rotate the HttpOnly cookie, mirroring the exact configuration used in the login controller (path, httpOnly, secure, sameSite, maxAge).

## Dependencies

This PR depends on #112 (fix/jwt-expiry) which must merge first, as it introduces `JWT_EXPIRY_MS` constant used in the cookie configuration.

## Testing

- Verify token refresh updates the HttpOnly cookie by inspecting Set-Cookie headers in the response
- Confirm the new cookie's expiration matches the new token's expiration
- Test that subsequent requests after refresh do not return 401 errors due to stale cookies