### PR TITLE
feat(suppliers): agregar parámetros sortBy y sortOrder

### DIFF
--- a/src/constants/suppliers.js
+++ b/src/constants/suppliers.js
@@ -27,6 +27,9 @@ const SUPPLIERS_VALIDATORS = Object.freeze({
   PAYMENT_DAYS_NEGATIVE: 'PAYMENT_DAYS_NEGATIVE'
 });
 
+const SORT_WHITELIST = Object.freeze(['id', 'name', 'trade_name', 'is_active', 'createdAt']);
+
 module.exports = {
-  SUPPLIERS_VALIDATORS
+  SUPPLIERS_VALIDATORS,
+  SORT_WHITELIST
 };

--- a/src/controllers/suppliers.js
+++ b/src/controllers/suppliers.js
@@ -22,7 +22,7 @@ const getRecords = async(req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { suppliers, total } = await getAllSuppliers(page, limit, search);
+    const { suppliers, total } = await getAllSuppliers(page, limit, search, data.sortBy, data.sortOrder);
     res.send(buildPaginationResponse('suppliers', suppliers, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS -> ${error}`);

--- a/src/services/suppliers.js
+++ b/src/services/suppliers.js
@@ -2,6 +2,12 @@
 
 const { suppliers, municipalities } = require('../models/index');
 const { Op } = require('sequelize');
+const { SORT_WHITELIST } = require('../constants/suppliers');
+
+const sanitizeSort = (sortBy, sortOrder) => ({
+  safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
+  safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
+});
 
 const attributes = [
   'id',
@@ -27,8 +33,9 @@ const attributes = [
 
 const municipalityAttributes = ['id', 'name'];
 
-const getAllSuppliers = async(page = 1, limit = 20, search = '') => {
+const getAllSuppliers = async(page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = search ? { name: { [Op.like]: `%${search}%` } } : {};
   const { count, rows } = await suppliers.findAndCountAll({
     attributes,
@@ -40,6 +47,7 @@ const getAllSuppliers = async(page = 1, limit = 20, search = '') => {
         attributes: municipalityAttributes
       }
     ],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true

--- a/src/validators/suppliers.js
+++ b/src/validators/suppliers.js
@@ -2,11 +2,12 @@
 
 const { check } = require('express-validator');
 const validateResults = require('../utils/handleValidator');
-const { paginationChecks } = require('./shared');
-const { SUPPLIERS_VALIDATORS } = require('../constants/suppliers');
+const { paginationChecks, sortChecks } = require('./shared');
+const { SUPPLIERS_VALIDATORS, SORT_WHITELIST } = require('../constants/suppliers');
 
 const validateGetAll = [
   ...paginationChecks,
+  ...sortChecks(SORT_WHITELIST),
   check('search').optional().isString().trim(),
   (req, res, next) => validateResults(req, res, next)
 ];


### PR DESCRIPTION
## Resumen

Se agrega funcionalidad de ordenamiento al endpoint `GET /suppliers` siguiendo el mismo patrón ya implementado en `GET /sales`.

## Campos permitidos en `sort_by`

El parámetro `sortBy` acepta los siguientes valores:
- `id` (por defecto)
- `name`
- `trade_name`
- `is_active`
- `createdAt`

El parámetro `sortOrder` acepta `ASC` o `DESC` (por defecto).

## Ejemplo de request

```
GET /api/suppliers?page=1&limit=20&sortBy=name&sortOrder=ASC
```

## Cambios implementados

- **constants/suppliers.js**: Agrega `SORT_WHITELIST` con campos permitidos
- **validators/suppliers.js**: Aplica `sortChecks` para validar parámetros de ordenamiento
- **services/suppliers.js**: Implementa helper `sanitizeSort` y aplica ordenamiento en query
- **controllers/suppliers.js**: Pasa parámetros `sortBy` y `sortOrder` al servicio