### PR TITLE
feat(purchases): agregar sort y search al endpoint de compras por sucursal

### DIFF
--- a/src/constants/purchases.js
+++ b/src/constants/purchases.js
@@ -65,4 +65,6 @@ const PURCHASES_VALIDATORS = Object.freeze({
   NOTES_INVALID: 'Las observaciones deben ser texto'
 });
 
-module.exports = { PURCHASES_VALIDATORS };
+const SORT_WHITELIST = Object.freeze(['id', 'purch_date', 'supplier_id', 'purch_type', 'status', 'createdAt', 'supplier_name']);
+
+module.exports = { PURCHASES_VALIDATORS, SORT_WHITELIST };

--- a/src/controllers/purchases.js
+++ b/src/controllers/purchases.js
@@ -55,7 +55,8 @@ const getRecordsByBranch = async (req, res) => {
   try {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
-    const { purchases, total } = await getPurchasesByBranch(data.branch_id, page, limit);
+    const search = data.search ?? '';
+    const { purchases, total } = await getPurchasesByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder);
     res.send(buildPaginationResponse('purchases', purchases, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_BRANCH -> ${error}`, 400);

--- a/src/services/purchases.js
+++ b/src/services/purchases.js
@@ -1,7 +1,19 @@
 const { purchases, purchaseDetails, suppliers, branches, users, products } = require('../models/index');
 const { sequelize } = require('../models/index');
+const { Op } = require('sequelize');
 const { updateFromPurchase } = require('./productStocks');
 const accountingEngine = require('./accountingEngine.service');
+const { SORT_WHITELIST } = require('../constants/purchases');
+
+const sanitizeSort = (sortBy, sortOrder) => ({
+  safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'purch_date',
+  safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
+});
+
+const buildSortOrder = (safeSortBy, safeSortOrder) =>
+  safeSortBy === 'supplier_name'
+    ? [[{ model: suppliers, as: 'supplier' }, 'name', safeSortOrder]]
+    : [[safeSortBy, safeSortOrder]];
 
 const purchaseAttributes = [
   'id',
@@ -112,13 +124,26 @@ const getPurchasesBySupplier = async (supplierId, page = 1, limit = 20) => {
   return { purchases: rows, total: count };
 };
 
-const getPurchasesByBranch = async (branchId, page = 1, limit = 20) => {
+const getPurchasesByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'purch_date', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
+  const supplierInclude = {
+    model: suppliers,
+    as: 'supplier',
+    attributes: supplierAttributes,
+    ...(search ? { where: { name: { [Op.like]: `%${search}%` } }, required: true } : {})
+  };
+  const includes = [
+    supplierInclude,
+    { model: branches, as: 'branch', attributes: branchAttributes },
+    { model: users, as: 'user', attributes: userAttributes },
+    { model: purchaseDetails, as: 'details', attributes: detailAttributes, include: detailIncludes }
+  ];
   const { count, rows } = await purchases.findAndCountAll({
     attributes: purchaseAttributes,
     where: { branch_id: branchId },
-    include: purchaseIncludes,
-    order: [['purch_date', 'DESC']],
+    include: includes,
+    order: buildSortOrder(safeSortBy, safeSortOrder),
     limit,
     offset,
     distinct: true

--- a/src/validators/purchases.js
+++ b/src/validators/purchases.js
@@ -1,7 +1,7 @@
 const { check } = require('express-validator');
 const validateResults = require('../utils/handleValidator');
-const { PURCHASES_VALIDATORS } = require('../constants/purchases');
-const { paginationChecks } = require('./shared');
+const { PURCHASES_VALIDATORS, SORT_WHITELIST } = require('../constants/purchases');
+const { paginationChecks, sortChecks } = require('./shared');
 
 const validateGetAll = [
   ...paginationChecks,
@@ -31,6 +31,8 @@ const validateGetByBranch = [
     .notEmpty().withMessage(PURCHASES_VALIDATORS.BRANCH_ID_IS_EMPTY).bail()
     .isInt().withMessage(PURCHASES_VALIDATORS.BRANCH_ID_INVALID).bail(),
   ...paginationChecks,
+  ...sortChecks(SORT_WHITELIST),
+  check('search').optional().isString().trim(),
   (req, res, next) => validateResults(req, res, next)
 ];
 


### PR DESCRIPTION
## Resumen
Se implementan capacidades de ordenamiento y búsqueda en el endpoint GET `/api/purchases/branch/:branch_id` para mejorar la usabilidad al gestionar compras por sucursal.

## Cambios principales
- **sort_by**: Campo por el que ordenar (defecto: `purch_date`)
- **sort_order**: Dirección del ordenamiento: `ASC` o `DESC` (defecto: `DESC`)
- **search**: Búsqueda de texto opcional en nombres de proveedores

## Campos permitidos en sort_by
- `id` — ID de la compra
- `purch_date` — Fecha de la compra
- `supplier_id` — ID del proveedor
- `purch_type` — Tipo de compra
- `status` — Estado de la compra
- `createdAt` — Fecha de creación
- `supplier_name` — Nombre del proveedor (caso especial)

**Nota especial:** El campo `supplier_name` requiere un JOIN a la tabla `suppliers` para funcionar correctamente. Esto se maneja dinámicamente en el helper `buildSortOrder` para garantizar que la asociación se establezca de forma apropiada.

## Validación y seguridad
- La constante `SORT_WHITELIST` valida los campos permitidos en `sort_by`, previniendo inyección SQL
- El parámetro `search` se sanitiza usando Sequelize `Op.like` con wildcards
- Los parámetros inválidos regresan a valores por defecto sin errores

## Ejemplo de request
```http
GET /api/purchases/branch/1?page=1&limit=20&sort_by=supplier_name&sort_order=ASC&search=acme
```

## Archivos modificados
- `src/constants/purchases.js` — Nueva constante `SORT_WHITELIST`
- `src/validators/purchases.js` — Validación de `sort_by`, `sort_order` y `search`
- `src/services/purchases.js` — Helpers `sanitizeSort` y `buildSortOrder`, lógica en `getPurchasesByBranch`
- `src/controllers/purchases.js` — Paso de parámetros al servicio