### PR TITLE
feat(sales): add sales_type filter to customer endpoint

### DIFF
--- a/src/controllers/sales.js
+++ b/src/controllers/sales.js
@@ -47,7 +47,8 @@ const getRecordsByCustomer = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { sales, total } = await getSalesByCustomer(data.customer_id, page, limit, search);
+    const salesType = data.sales_type ?? null;
+    const { sales, total } = await getSalesByCustomer(data.customer_id, page, limit, search, salesType);
     res.send(buildPaginationResponse('sales', sales, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_CUSTOMER -> ${error}`, 400);

--- a/src/routes/sales.js
+++ b/src/routes/sales.js
@@ -120,6 +120,12 @@ router.get('/', [
  *        schema:
  *          type: string
  *        description: Texto para filtrar resultados
+ *      - in: query
+ *        name: sales_type
+ *        schema:
+ *          type: string
+ *          enum: [Contado, Credito]
+ *        description: Filtrar por tipo de venta
  *      responses:
  *        '200':
  *          description: Lista de ventas del cliente paginada

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -101,10 +101,11 @@ const getSale = async (id) => {
   });
 };
 
-const getSalesByCustomer = async (customerId, page = 1, limit = 20, search = '') => {
+const getSalesByCustomer = async (customerId, page = 1, limit = 20, search = '', salesType = null) => {
   const offset = (page - 1) * limit;
   const where = { customer_id: customerId };
   if (search) where.ticket = { [Op.like]: `%${search}%` };
+  if (salesType) where.sales_type = salesType;
   const { count, rows } = await sales.findAndCountAll({
     attributes: saleAttributes,
     where,

--- a/src/validators/sales.js
+++ b/src/validators/sales.js
@@ -25,6 +25,7 @@ const validateGetByCustomer = [
     .isInt().withMessage(SALES_VALIDATORS.CUSTOMER_ID_INVALID).bail(),
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  check('sales_type').optional().isIn(['Contado', 'Credito']).withMessage('sales_type must be Contado or Credito'),
   (req, res, next) => validateResults(req, res, next)
 ];
 


### PR DESCRIPTION
## Summary

Add optional `sales_type` query parameter to filter customer sales by payment type (Contado | Credito).

- Add optional query param validation in validator
- Extract and pass `sales_type` to service layer
- Implement WHERE filter in database query
- Update OpenAPI/Swagger documentation

## Test plan

- [x] Lint and tests pass
- [x] All 4 files staged and committed
- [x] New endpoint supports both Contado and Credito filter values
- [x] Query parameter is optional (backwards compatible)