### PR TITLE
feat: atomic sale deletion with inventory revert and password verification

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -135,4 +135,21 @@ const refreshCtrl = async(req, res) => {
   }
 };
 
-module.exports = { registerAdminCtrl, registerCtrl, loginCtrl, refreshCtrl, logoutCtrl };
+const verifyPasswordCtrl = async (req, res) => {
+  try {
+    const { password } = matchedData(req);
+    const user = await users.findByPk(req.user.id, { attributes: ['password'] });
+    if (!user) return res.status(401).json({ errors: [{ type: 'client', name: 'password', message: 'Contraseña incorrecta' }] });
+    const valid = await compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({
+        errors: [{ type: 'client', name: 'password', message: 'Contraseña incorrecta' }]
+      });
+    }
+    res.send({ ok: true });
+  } catch (error) {
+    handleHttpError(res, 'ERROR_VERIFY_PASSWORD', 400);
+  }
+};
+
+module.exports = { registerAdminCtrl, registerCtrl, loginCtrl, refreshCtrl, logoutCtrl, verifyPasswordCtrl };

--- a/src/controllers/sales.js
+++ b/src/controllers/sales.js
@@ -145,7 +145,8 @@ const cancelRecord = async (req, res) => {
 const deleteRecord = async (req, res) => {
   try {
     const { id } = matchedData(req);
-    const result = await deleteSale(id);
+    const userId = req.user.id;
+    const result = await deleteSale(id, userId);
 
     if (result && result.error === 'NOT_FOUND') {
       handleHttpError(res, `SALE ${id} NOT EXISTS`, 404);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-const { registerAdminCtrl, registerCtrl, loginCtrl, refreshCtrl, logoutCtrl } = require('../controllers/auth');
-const { validateLogin, validateRegister } = require('../validators/auth');
+const { registerAdminCtrl, registerCtrl, loginCtrl, refreshCtrl, logoutCtrl, verifyPasswordCtrl } = require('../controllers/auth');
+const { validateLogin, validateRegister, validateVerifyPassword } = require('../validators/auth');
 
 const authMidleware = require('../middlewares/session');
 const conditionalAuthForSuperAdmin = require('../middlewares/conditionalAuth');
@@ -151,5 +151,61 @@ router.post('/refresh', [authMidleware], refreshCtrl);
  *         description: Token inválido o ausente
  */
 router.post('/logout', authMidleware, logoutCtrl);
+
+/**
+ * @openapi
+ * /auth/verify-password:
+ *   post:
+ *     tags:
+ *       - auth
+ *     summary: Verificar contraseña del usuario activo
+ *     description: Confirma que la contraseña enviada corresponde al usuario autenticado. Usado para autorizar acciones sensibles sin cerrar sesión.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - password
+ *             properties:
+ *               password:
+ *                 type: string
+ *     responses:
+ *       '200':
+ *         description: Contraseña válida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   example: true
+ *       '401':
+ *         description: Contraseña incorrecta
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 errors:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       type:
+ *                         type: string
+ *                         example: client
+ *                       name:
+ *                         type: string
+ *                         example: password
+ *                       message:
+ *                         type: string
+ *                         example: Contraseña incorrecta
+ */
+router.post('/verify-password', [authMidleware, validateVerifyPassword], verifyPasswordCtrl);
 
 module.exports = router;

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -1,11 +1,12 @@
 const {
   sales, saleDetails, saleInstallments, salePayments, saleDeliveries,
   customers, customerAddresses, employees, branches, users, products,
-  productStocks, stockMovements, campaignProducts
+  productStocks, stockMovements, campaignProducts, accountingVouchers: avModel
 } = require('../models/index');
 const { sequelize } = require('../models/index');
 const { Op } = require('sequelize');
 const accountingEngine = require('./accountingEngine.service');
+const { cancelVoucher } = require('./accountingVouchers');
 const { TICKET_CONFIG, SORT_WHITELIST } = require('../constants/sales');
 const {
   getActiveConfig,
@@ -591,21 +592,76 @@ const cancelSale = async (id, userId) => {
   }
 };
 
-const deleteSale = async (id) => {
-  const data = await sales.findByPk(id);
-  if (!data) return { error: 'NOT_FOUND' };
+const deleteSale = async (id, userId) => {
+  const sale = await sales.findOne({
+    where: { id },
+    include: [{ model: saleDetails, as: 'details', attributes: detailAttributes }]
+  });
 
-  if (data.status !== 'Pendiente') {
-    return { error: 'SALE_CANNOT_BE_DELETED' };
-  }
+  if (!sale) return { error: 'NOT_FOUND' };
+  if (sale.sales_type !== 'Contado') return { error: 'SALE_DELETE_ONLY_CONTADO' };
 
   const activePayments = await salePayments.count({ where: { sale_id: id } });
-  if (activePayments > 0) {
-    return { error: 'SALE_HAS_ACTIVE_PAYMENTS' };
+  if (activePayments > 0) return { error: 'SALE_HAS_ACTIVE_PAYMENTS' };
+
+  const voucher = await avModel.findOne({
+    where: { reference_type: 'sale', reference_id: id },
+    include: [{ association: 'period', attributes: ['status'] }]
+  });
+  if (voucher && voucher.period && voucher.period.status !== 'abierto') {
+    return { error: 'SALE_PERIOD_CLOSED' };
   }
 
-  await sales.destroy({ where: { id } });
-  return { deleted: true };
+  const transaction = await sequelize.transaction();
+  try {
+    for (const detail of sale.details) {
+      const qty = parseFloat(detail.qty);
+      const stock = await productStocks.findOne({
+        where: { bar_code: `${detail.product_id}-${detail.purch_id}`, branch_id: sale.branch_id },
+        transaction,
+        lock: transaction.LOCK.UPDATE
+      });
+
+      if (stock) {
+        stock.quantity = parseFloat((parseFloat(stock.quantity) + qty).toFixed(3));
+        stock.last_count_date = new Date();
+        await stock.save({ transaction });
+      }
+
+      await stockMovements.create({
+        product_id: detail.product_id,
+        branch_id: sale.branch_id,
+        reference_type: 'adjustment',
+        reference_id: id,
+        qty_change: qty,
+        notes: `Reversal por eliminación de venta #${id}`,
+        created_by: userId
+      }, { transaction });
+    }
+
+    if (parseFloat(sale.points_redeemed) > 0) {
+      await voidRedeemPoints(sale.customer_id, id, userId, transaction);
+    }
+    if (parseFloat(sale.points_earned) > 0) {
+      await voidEarnPoints(sale.customer_id, id, userId, transaction);
+    }
+
+    await sales.destroy({ where: { id }, transaction });
+
+    await transaction.commit();
+
+    if (voucher) {
+      cancelVoucher(voucher.id)
+        .catch(err =>
+          console.error(`[AccountingEngine] Error revirtiendo póliza de venta #${id}:`, err.message)
+        );
+    }
+
+    return { deleted: true };
+  } catch (error) {
+    await transaction.rollback();
+    throw error;
+  }
 };
 
 module.exports = {

--- a/src/tests/23_sales.test.js
+++ b/src/tests/23_sales.test.js
@@ -477,13 +477,12 @@ describe('[SALES] Test api sales /api/sales/', () => {
   // DELETE /api/sales/:id
   // ============================================
   describe('DELETE /api/sales/:id', () => {
-    test('18. Soft delete venta Pendiente sin pagos. Expect 200', async () => {
-      // Create a new credit sale for deletion
+    test('18. Soft delete venta Contado sin pagos. Expect 200', async () => {
       const newSaleRes = await api
         .post('/api/sales')
         .auth(Token, { type: 'bearer' })
         .set('x-branch-id', '1')
-        .send(saleCreateCredito(customerId, addressId, purchaseId))
+        .send(saleCreateContado(customerId, addressId, purchaseId))
         .expect(200);
 
       const deleteSaleId = newSaleRes.body.sale.id;

--- a/src/validators/auth.js
+++ b/src/validators/auth.js
@@ -113,4 +113,11 @@ const validateChangePassword = [
   }
 ];
 
-module.exports = { validateRegister, validateLogin, validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword };
+const validateVerifyPassword = [
+  check('password')
+    .exists().withMessage(REGISTER.PASSWORD_NOT_EXISTS).bail()
+    .notEmpty().withMessage(REGISTER.PASSWORD_EMPTY).bail(),
+  (req, res, next) => validateResults(req, res, next)
+];
+
+module.exports = { validateRegister, validateLogin, validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword, validateVerifyPassword };


### PR DESCRIPTION
## Summary

- **`DELETE /api/sales/:id`** reescrito como operación atómica: valida que la venta sea Contado, que no tenga pagos activos y que su póliza contable esté en un periodo abierto; revierte stock con `stockMovements`, anula puntos de lealtad, ejecuta soft-delete y cancela la póliza contable en fire-and-forget.
- **`POST /auth/verify-password`** nuevo endpoint para que el operador confirme su contraseña antes de acciones sensibles, sin desloguear la sesión. Responde 401 con formato de error por campo compatible con el interceptor del frontend.

## Test plan

- [x] `DELETE /api/sales/:id` con venta Contado sin pagos y periodo abierto → 200 `{ deleted: true }`, stock revertido, `stockMovement` creado con `reference_type='adjustment'`
- [x] Mismo endpoint con venta Crédito → 422 `SALE_DELETE_ONLY_CONTADO`
- [x] Mismo endpoint con venta que tiene pagos → 422 `SALE_HAS_ACTIVE_PAYMENTS`
- [x] Mismo endpoint con póliza en periodo cerrado → 422 `SALE_PERIOD_CLOSED`
- [x] `POST /auth/verify-password` con contraseña correcta → 200 `{ ok: true }`
- [x] `POST /auth/verify-password` con contraseña incorrecta → 401 `{ errors: [{ type: 'client', name: 'password', message: 'Contraseña incorrecta' }] }`
- [x] `POST /auth/verify-password` sin token → 401
- [x] `pnpm test` completo en verde