### PR TITLE
feat(sales): add modified_by audit field

### DIFF
--- a/src/database/migrations/20260519000000-add-audit-fields-to-sales.js
+++ b/src/database/migrations/20260519000000-add-audit-fields-to-sales.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('sales', 'modified_by', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+      after: 'notes'
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('sales', 'modified_by');
+  }
+};

--- a/src/models/sales.js
+++ b/src/models/sales.js
@@ -9,6 +9,7 @@ module.exports = (sequelize, DataTypes) => {
       this.belongsTo(models.customerAddresses, { as: 'customerAddress', foreignKey: 'customer_address_id' });
       this.belongsTo(models.employees, { as: 'employee', foreignKey: 'employee_id' });
       this.belongsTo(models.users, { as: 'user', foreignKey: 'user_id' });
+      this.belongsTo(models.users, { as: 'modifiedBy', foreignKey: 'modified_by' });
       this.belongsTo(models.priceLists, { as: 'priceList', foreignKey: 'price_list_id' });
       this.hasMany(models.saleDetails, { as: 'details', foreignKey: 'sale_id' });
       this.hasMany(models.salePayments, { as: 'payments', foreignKey: 'sale_id' });
@@ -128,6 +129,10 @@ module.exports = (sequelize, DataTypes) => {
     },
     notes: {
       type: DataTypes.TEXT,
+      allowNull: true
+    },
+    modified_by: {
+      type: DataTypes.INTEGER,
       allowNull: true
     }
   }, {

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -582,6 +582,7 @@ const cancelSale = async (id, userId) => {
 
     sale.status = 'Cancelado';
     sale.due_payment = 0;
+    sale.modified_by = userId;
     await sale.save({ transaction });
 
     await transaction.commit();
@@ -646,7 +647,8 @@ const deleteSale = async (id, userId) => {
       await voidEarnPoints(sale.customer_id, id, userId, transaction);
     }
 
-    await sales.destroy({ where: { id }, transaction });
+    await sale.update({ modified_by: userId }, { transaction });
+    await sale.destroy({ transaction });
 
     await transaction.commit();
 


### PR DESCRIPTION
## Summary

- Adds `modified_by` column to `sales` table to record which user cancelled or deleted a sale
- Migration uses `DEFAULT 1` so existing rows are not affected
- `cancelSale` sets `modified_by` before saving the status change
- `deleteSale` sets `modified_by` via `update` before the soft-delete (`destroy`)
- Model declares the field and a `belongsTo` association (`modifiedBy → users`)

## Test plan

- [ ] Correr `npx sequelize-cli db:migrate` en dev y verificar que la columna aparece en `sales`
- [ ] Cancelar una venta y confirmar que `modified_by` queda con el `user_id` del usuario autenticado
- [ ] Eliminar una venta (Contado) y confirmar que `modified_by` queda registrado en el soft-delete
- [ ] Verificar que ventas existentes quedan con `modified_by = NULL` y `created_by` no fue alterado