### PR TITLE
feat(customers): add sorting support to list endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "testSequencer": "./testSequencer.js"
   },
   "lint-staged": {
-    "*.(js)": "pnpm run lint:fix"
+    "*.(js)": "eslint --fix --ignore-path .gitignore"
   },
   "pnpm": {
     "overrides": {

--- a/src/constants/customers.js
+++ b/src/constants/customers.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const SORT_WHITELIST = Object.freeze(['id', 'name', 'email', 'is_active', 'created_at']);
+
+module.exports = {
+  SORT_WHITELIST
+};

--- a/src/controllers/customers.js
+++ b/src/controllers/customers.js
@@ -23,7 +23,7 @@ const getRecords = async(req, res) => {
     const { page = 1, limit = 20, search = '' } = data;
     const pageNum = Number(page);
     const limitNum = Number(limit);
-    const { customers, total } = await getAllCustomers(pageNum, limitNum, search);
+    const { customers, total } = await getAllCustomers(pageNum, limitNum, search, data.sortBy, data.sortOrder);
     res.send({
       customers,
       pagination: { total, page: pageNum, limit: limitNum, totalPages: Math.ceil(total / limitNum) }
@@ -65,7 +65,7 @@ const getRecordsByBranch = async(req, res) => {
     const { branchId, page = 1, limit = 20, search = '' } = data;
     const pageNum = Number(page);
     const limitNum = Number(limit);
-    const { customers, total } = await getCustomersByBranch(branchId, pageNum, limitNum, search);
+    const { customers, total } = await getCustomersByBranch(branchId, pageNum, limitNum, search, data.sortBy, data.sortOrder);
     res.send({
       customers,
       pagination: { total, page: pageNum, limit: limitNum, totalPages: Math.ceil(total / limitNum) }
@@ -86,7 +86,7 @@ const getRecordsByMunicipality = async(req, res) => {
     const { municipalityId, page = 1, limit = 20, search = '' } = data;
     const pageNum = Number(page);
     const limitNum = Number(limit);
-    const { customers, total } = await getCustomersByMunicipality(municipalityId, pageNum, limitNum, search);
+    const { customers, total } = await getCustomersByMunicipality(municipalityId, pageNum, limitNum, search, data.sortBy, data.sortOrder);
     res.send({
       customers,
       pagination: { total, page: pageNum, limit: limitNum, totalPages: Math.ceil(total / limitNum) }

--- a/src/services/customers.js
+++ b/src/services/customers.js
@@ -2,6 +2,12 @@ const { customers, customerAddresses, municipalities, branches, users } = requir
 const { Op } = require('sequelize');
 const { encrypt } = require('../utils/handlePassword');
 const { ROLE } = require('../constants/roles');
+const { SORT_WHITELIST } = require('../constants/customers');
+
+const sanitizeSort = (sortBy, sortOrder) => ({
+  safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
+  safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
+});
 
 const attributes = [
   'id', 'name', 'email', 'phone', 'mobile', 'tax_id', 'is_international',
@@ -13,8 +19,9 @@ const municipalityAttributes = ['id', 'name'];
 const branchAttributes = ['id', 'name'];
 const userAttributes = ['id', 'email', 'role'];
 
-const getAllCustomers = async(page = 1, limit = 20, search = '') => {
+const getAllCustomers = async(page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = search ? { name: { [Op.like]: `%${search}%` } } : {};
   const { count, rows } = await customers.findAndCountAll({
     attributes,
@@ -36,6 +43,7 @@ const getAllCustomers = async(page = 1, limit = 20, search = '') => {
         attributes: userAttributes
       }
     ],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true
@@ -78,8 +86,9 @@ const getCustomer = async(id) => {
   return result;
 };
 
-const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '') => {
+const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { branch_id: branchId };
   if (search) where.name = { [Op.like]: `%${search}%` };
   const { count, rows } = await customers.findAndCountAll({
@@ -98,6 +107,7 @@ const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '') 
         required: true
       }
     ],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true
@@ -106,8 +116,9 @@ const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '') 
   return { customers: rows, total: count };
 };
 
-const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, search = '') => {
+const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
+  const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { municipality_id: municipalityId };
   if (search) where.name = { [Op.like]: `%${search}%` };
   const { count, rows } = await customers.findAndCountAll({
@@ -126,6 +137,7 @@ const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, s
         attributes: branchAttributes
       }
     ],
+    order: [[safeSortBy, safeSortOrder]],
     limit,
     offset,
     distinct: true

--- a/src/validators/customers.js
+++ b/src/validators/customers.js
@@ -1,14 +1,12 @@
 const { check, body } = require('express-validator');
 const validateResults = require('../utils/handleValidator');
 const { CUSTOMERS_VALIDATORS } = require('../constants/errors');
+const { paginationChecks, sortChecks } = require('./shared');
+const { SORT_WHITELIST } = require('../constants/customers');
 
 const validateGetAll = [
-  check('page')
-    .optional()
-    .isInt({ min: 1 }).withMessage('page debe ser un entero mayor a 0'),
-  check('limit')
-    .optional()
-    .isInt({ min: 1, max: 100 }).withMessage('limit debe ser un entero entre 1 y 100'),
+  ...paginationChecks,
+  ...sortChecks(SORT_WHITELIST),
   check('search').optional().isString().trim(),
   (req, res, next) => {
     return validateResults(req, res, next);
@@ -127,12 +125,8 @@ const validateGetByBranch = [
     .exists().withMessage('El ID de sucursal es requerido').bail()
     .notEmpty().withMessage('El ID de sucursal no puede estar vacío').bail()
     .isNumeric().withMessage('El ID de sucursal debe ser numérico'),
-  check('page')
-    .optional()
-    .isInt({ min: 1 }).withMessage('page debe ser un entero mayor a 0'),
-  check('limit')
-    .optional()
-    .isInt({ min: 1, max: 100 }).withMessage('limit debe ser un entero entre 1 y 100'),
+  ...paginationChecks,
+  ...sortChecks(SORT_WHITELIST),
   check('search').optional().isString().trim(),
   (req, res, next) => {
     return validateResults(req, res, next);
@@ -144,12 +138,8 @@ const validateGetByMunicipality = [
     .exists().withMessage('El ID de municipio es requerido').bail()
     .notEmpty().withMessage('El ID de municipio no puede estar vacío').bail()
     .isNumeric().withMessage('El ID de municipio debe ser numérico'),
-  check('page')
-    .optional()
-    .isInt({ min: 1 }).withMessage('page debe ser un entero mayor a 0'),
-  check('limit')
-    .optional()
-    .isInt({ min: 1, max: 100 }).withMessage('limit debe ser un entero entre 1 y 100'),
+  ...paginationChecks,
+  ...sortChecks(SORT_WHITELIST),
   check('search').optional().isString().trim(),
   (req, res, next) => {
     return validateResults(req, res, next);


### PR DESCRIPTION
## Summary

- Add `sortBy` / `sortOrder` query params to `GET /customers`, `GET /customers/branch/:id` and `GET /customers/municipality/:id`
- Follow the same pattern as suppliers: `SORT_WHITELIST` constant, `sanitizeSort` helper in the service, and shared `sortChecks` validator
- Fix pre-existing bug in `lint-staged` config where `pnpm run lint:fix` was not receiving file paths correctly due to the `--` separator

## Allowed values

| Param | Values | Default |
|---|---|---|
| `sortBy` | `id`, `name`, `email`, `is_active`, `created_at` | `id` |
| `sortOrder` | `ASC`, `DESC` | `DESC` |

## Test plan

- [x] All 1342 existing tests pass
- [x] `GET /api/customers?sortBy=name&sortOrder=ASC` returns customers sorted by name ascending
- [x] `GET /api/customers/branch/:id?sortBy=created_at&sortOrder=DESC` returns sorted results
- [x] `GET /api/customers/municipality/:id?sortBy=email&sortOrder=ASC` returns sorted results
- [x] Invalid `sortBy` value falls back silently to `id`
- [x] Invalid `sortOrder` value returns `400 INVALID_SORT_ORDER`