### PR TITLE
feat(middleware): add user-based rate limiting

### DIFF
--- a/src/middlewares/rateLimiters.js
+++ b/src/middlewares/rateLimiters.js
@@ -1,5 +1,9 @@
 const rateLimit = require('express-rate-limit');
 
+// Limitar por usuario autenticado; si no hay token (ruta pública), caer a IP
+const keyGenerator = (req) =>
+  req.user?.id ? `user_${req.user.id}` : req.ip;
+
 /**
  * Middleware condicional que bypasea el rate limiting en entorno de test
  * y aplica el rate limiter en otros entornos
@@ -22,13 +26,14 @@ const createConditionalLimiter = (limiterConfig) => {
  * Permite mayor volumen ya que son operaciones menos costosas
  */
 const readLimiter = createConditionalLimiter({
-  windowMs: 60 * 1000, // 1 minuto
-  max: 60, // 60 requests por minuto
+  windowMs: 60 * 1000,
+  max: 60,
+  keyGenerator,
   message: {
     error: 'Demasiadas solicitudes de lectura, intente nuevamente en un minuto'
   },
-  standardHeaders: true, // Retornar info de rate limit en headers `RateLimit-*`
-  legacyHeaders: false // Deshabilitar headers `X-RateLimit-*`
+  standardHeaders: true,
+  legacyHeaders: false
 });
 
 /**
@@ -36,8 +41,9 @@ const readLimiter = createConditionalLimiter({
  * Más restrictivo para prevenir abuso en creación/modificación
  */
 const writeLimiter = createConditionalLimiter({
-  windowMs: 60 * 1000, // 1 minuto
-  max: 20, // 20 requests por minuto
+  windowMs: 60 * 1000,
+  max: 20,
+  keyGenerator,
   message: {
     error: 'Demasiadas solicitudes de escritura, intente nuevamente en un minuto'
   },
@@ -50,8 +56,9 @@ const writeLimiter = createConditionalLimiter({
  * Intermedio entre lectura y escritura, ya que pueden ser costosas
  */
 const searchLimiter = createConditionalLimiter({
-  windowMs: 60 * 1000, // 1 minuto
-  max: 30, // 30 requests por minuto
+  windowMs: 60 * 1000,
+  max: 30,
+  keyGenerator,
   message: {
     error: 'Demasiadas solicitudes de búsqueda, intente nuevamente en un minuto'
   },
@@ -64,8 +71,9 @@ const searchLimiter = createConditionalLimiter({
  * Muy restrictivo para prevenir eliminaciones masivas accidentales o maliciosas
  */
 const deleteLimiter = createConditionalLimiter({
-  windowMs: 60 * 1000, // 1 minuto
-  max: 10, // 10 requests por minuto
+  windowMs: 60 * 1000,
+  max: 10,
+  keyGenerator,
   message: {
     error: 'Demasiadas solicitudes de eliminación, intente nuevamente en un minuto'
   },


### PR DESCRIPTION
## Summary

Implement user-based rate limiting to prevent false positives from shared NAT/VPN environments while maintaining IP-based protection for unauthenticated routes.

## Problem

Legitimate users sharing a NAT or connecting through a VPN would hit rate limits due to requests being tracked by their shared IP address, causing service interruptions and poor user experience.

## Solution

- Added `keyGenerator` function that identifies clients by authenticated user ID (`user_${id}`) when a JWT token is present
- Falls back to IP address (`req.ip`) for unauthenticated requests
- Applied to all 4 rate limiters: `readLimiter`, `writeLimiter`, `searchLimiter`, and `deleteLimiter`
- Intentionally left `authLimiter` (in `server.js`) unchanged — it remains IP-based to protect the login route itself

## Changes

- **File modified:** `src/middlewares/rateLimiters.js`
- **Lines added:** keyGenerator function + keyGenerator option in each rate limiter config
- **Tests:** All existing tests pass (pre-commit hooks verified)

## Testing

- Full test suite runs successfully with the changes
- Rate limiters still function correctly in test environment (DISABLE_RATE_LIMIT=true)
- No breaking changes to existing rate limiting behavior