### PR TITLE
fix(middleware): use ipKeyGenerator for IPv6 normalization

### DIFF
--- a/src/middlewares/rateLimiters.js
+++ b/src/middlewares/rateLimiters.js
@@ -1,8 +1,8 @@
-const rateLimit = require('express-rate-limit');
+const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
 
 // Limitar por usuario autenticado; si no hay token (ruta pública), caer a IP
 const keyGenerator = (req) =>
-  req.user?.id ? `user_${req.user.id}` : req.ip;
+  req.user?.id ? `user_${req.user.id}` : ipKeyGenerator(req);
 
 /**
  * Middleware condicional que bypasea el rate limiting en entorno de test


### PR DESCRIPTION
## Summary

Fix rate limiter initialization error in express-rate-limit v8 by using the `ipKeyGenerator` helper to properly normalize IPv6 addresses.

- Destructures `ipKeyGenerator` from express-rate-limit
- Replaces `req.ip` with `ipKeyGenerator(req)` in the fallback path
- Prevents `ERR_ERL_KEY_GEN_IPV6` ValidationError on startup

## Why

The express-rate-limit v8 library requires using the `ipKeyGenerator` helper when implementing custom `keyGenerator` functions. This helper properly normalizes IPv6 addresses, preventing users from bypassing rate limits by rotating between IPv4 and IPv6 representations of the same address.

## Test plan

- [x] Lint passed (eslint)
- [x] All tests passed (full test suite)
- [x] No breaking changes to API