### PR TITLE
feat(municipalities): add POST, PUT, DELETE endpoints

### DIFF
--- a/src/constants/modules.js
+++ b/src/constants/modules.js
@@ -67,7 +67,13 @@ const MUNICIPALITIES = Object.freeze({
   VIEW_ALL: 'view_municipality',
   NAME_VIEW: 'Ver municipios',
   VIEW_STATE: 'view_state',
-  NAME_VIEW_STATE: 'Ver municipios por estado'
+  NAME_VIEW_STATE: 'Ver municipios por estado',
+  ADD: 'create_municipality',
+  NAME_ADD: 'Crear municipio',
+  UPDATE: 'update_municipality',
+  NAME_UPDATE: 'Modificar municipio',
+  DELETE: 'delete_municipality',
+  NAME_DELETE: 'Eliminar municipio'
 });
 
 const POSITION = Object.freeze({

--- a/src/controllers/municipalities.js
+++ b/src/controllers/municipalities.js
@@ -2,7 +2,7 @@ const { matchedData } = require('express-validator');
 const { handleHttpError } = require('../utils/handleErorr');
 const { getPaginationParams, buildPaginationResponse } = require('../utils/pagination');
 
-const { getMunicipality, getMunicipalitiesByStateId, getAll: getAllMunicipalities } = require('../services/municipalities');
+const { getMunicipality, getMunicipalitiesByStateId, getAll: getAllMunicipalities, addMunicipality, updateMunicipality, deleteMunicipality } = require('../services/municipalities');
 
 /**
  * Obtener detalle de un registro
@@ -49,4 +49,61 @@ const getAll = async(req, res) => {
   }
 };
 
-module.exports = { getById, getByStateId, getAll };
+/**
+ * Agregar un nuevo municipio
+ * @param {*} req
+ * @param {*} res
+ */
+const addRecord = async(req, res) => {
+  try {
+    const data = matchedData(req);
+    const municipality = await addMunicipality(data);
+    res.status(201).send({ municipality });
+  } catch (error) {
+    handleHttpError(res, `ERROR_ADDING_RECORD --> ${error}`, 400);
+  }
+};
+
+/**
+ * Actualizar un municipio
+ * @param {*} req
+ * @param {*} res
+ */
+const updateRecord = async(req, res) => {
+  try {
+    const data = matchedData(req);
+    const municipality = await updateMunicipality(data.id, data);
+
+    if (!municipality) {
+      handleHttpError(res, `MUNICIPALITY ${data.id} NOT EXISTS`, 404);
+      return;
+    }
+
+    res.send({ municipality });
+  } catch (error) {
+    handleHttpError(res, `ERROR_UPDATE_RECORD --> ${error}`, 400);
+  }
+};
+
+/**
+ * Eliminar un municipio (soft delete)
+ * @param {*} req
+ * @param {*} res
+ */
+const deleteRecord = async(req, res) => {
+  try {
+    const { id } = matchedData(req);
+    const result = await deleteMunicipality(id);
+
+    if (!result) {
+      handleHttpError(res, `MUNICIPALITY ${id} NOT EXISTS`, 404);
+      return;
+    }
+
+    res.send({ result });
+  } catch (error) {
+    handleHttpError(res, `ERROR_DELETE_RECORD --> ${error}`, 400);
+  }
+};
+
+module.exports = { getById, getByStateId, getAll, addRecord, updateRecord, deleteRecord };

--- a/src/database/seeders/json_files/privileges.js
+++ b/src/database/seeders/json_files/privileges.js
@@ -13,7 +13,10 @@ const data = [
 
   // Municipios
   { name: MUN.NAME_VIEW, codeName: MUN.VIEW_ALL, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
-  { name: MUN.NAME_VIEW_STATE, codeName: MUN.NAME_VIEW_STATE, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
+  { name: MUN.NAME_VIEW_STATE, codeName: MUN.VIEW_STATE, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
+  { name: MUN.NAME_ADD, codeName: MUN.ADD, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
+  { name: MUN.NAME_UPDATE, codeName: MUN.UPDATE, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
+  { name: MUN.NAME_DELETE, codeName: MUN.DELETE, module: MUN.MODULE_NAME, created_at: fecha, updated_at: fecha },
 
   // Sucursales
   { name: BR.NAME_ADD, codeName: BR.ADD, module: BR.MODULE_NAME, created_at: fecha, updated_at: fecha },

--- a/src/routes/municipalities.js
+++ b/src/routes/municipalities.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const router = express.Router();
 
-const { validateGetRecord, validateGetRecordByState, validateGetAll } = require('../validators/municipalities');
+const { validateGetRecord, validateGetRecordByState, validateGetAll, valiAddRecord, valiUpdateRecord, validateDeleteRecord } = require('../validators/municipalities');
 
 const authMidleware = require('../middlewares/session');
 const checkRol = require('../middlewares/rol');
-const { readLimiter } = require('../middlewares/rateLimiters');
+const { readLimiter, writeLimiter, deleteLimiter } = require('../middlewares/rateLimiters');
 
-const { getById, getByStateId, getAll } = require('../controllers/municipalities');
+const { getById, getByStateId, getAll, addRecord, updateRecord, deleteRecord } = require('../controllers/municipalities');
 
 const { MUNICIPALITIES: MUN } = require('../constants/modules');
 const { ROLE } = require('../constants/roles');
@@ -147,5 +147,144 @@ router.get('/state/:stateId', [
   authMidleware,
   validateGetRecordByState,
   checkRol([ROLE.USER, ROLE.ADMIN], MUN.VIEW_ALL)], getByStateId);
+
+/**
+ * @openapi
+ * /municipalities:
+ *      post:
+ *          tags:
+ *              - municipalities
+ *          summary: Crear nuevo municipio
+ *          description: Crear nuevo municipio previo inicio de sesion
+ *          security:
+ *              - bearerAuth: []
+ *          requestBody:
+ *              required: true
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          required:
+ *                              - name
+ *                              - state_id
+ *                          properties:
+ *                              name:
+ *                                  type: string
+ *                                  description: Nombre del municipio
+ *                              state_id:
+ *                                  type: integer
+ *                                  description: Identificador del estado al que pertenece
+ *          responses:
+ *              '201':
+ *                  description: Municipio creado correctamente
+ *                  content:
+ *                    application/json:
+ *                      schema:
+ *                        $ref: '#/components/schemas/municipalities'
+ *              '400':
+ *                  description: Error de validacion
+ *              '401':
+ *                  description: No autenticado
+ *              '403':
+ *                  description: Sin permiso
+ */
+router.post('/', [
+  writeLimiter,
+  authMidleware,
+  valiAddRecord,
+  checkRol([ROLE.USER, ROLE.ADMIN], MUN.ADD)
+], addRecord);
+
+/**
+ * @openapi
+ * /municipalities/{id}:
+ *      put:
+ *          tags:
+ *              - municipalities
+ *          summary: Actualizar municipio
+ *          description: Actualizar datos de un municipio previo inicio de sesion
+ *          security:
+ *              - bearerAuth: []
+ *          parameters:
+ *          - name: id
+ *            in: path
+ *            description: Identificador del municipio
+ *            required: true
+ *            schema:
+ *              type: integer
+ *          requestBody:
+ *              required: true
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          required:
+ *                              - name
+ *                              - state_id
+ *                          properties:
+ *                              name:
+ *                                  type: string
+ *                                  description: Nuevo nombre del municipio
+ *                              state_id:
+ *                                  type: integer
+ *                                  description: Identificador del estado al que pertenece
+ *          responses:
+ *              '200':
+ *                  description: Municipio actualizado correctamente
+ *                  content:
+ *                    application/json:
+ *                      schema:
+ *                        $ref: '#/components/schemas/municipalities'
+ *              '400':
+ *                  description: Error de validacion
+ *              '401':
+ *                  description: No autenticado
+ *              '403':
+ *                  description: Sin permiso
+ *              '404':
+ *                  description: Municipio no encontrado
+ */
+router.put('/:id', [
+  writeLimiter,
+  authMidleware,
+  valiUpdateRecord,
+  checkRol([ROLE.USER, ROLE.ADMIN], MUN.UPDATE)
+], updateRecord);
+
+/**
+ * @openapi
+ * /municipalities/{id}:
+ *      delete:
+ *          tags:
+ *              - municipalities
+ *          summary: Eliminacion de municipio
+ *          description: Eliminacion logica de un municipio
+ *          security:
+ *              - bearerAuth: []
+ *          parameters:
+ *          - name: id
+ *            in: path
+ *            description: Identificador del municipio
+ *            required: true
+ *            schema:
+ *              type: integer
+ *          responses:
+ *              '200':
+ *                  description: El municipio se ha marcado como eliminado satisfactoriamente
+ *              '400':
+ *                  description: Id de municipio invalido
+ *              '401':
+ *                  description: No autenticado
+ *              '403':
+ *                  description: Sin permiso
+ *              '404':
+ *                  description: Municipio no encontrado
+ */
+router.delete('/:id', [
+  deleteLimiter,
+  authMidleware,
+  validateDeleteRecord,
+  checkRol([ROLE.USER, ROLE.ADMIN], MUN.DELETE)
+], deleteRecord);
 
 module.exports = router;

--- a/src/services/municipalities.js
+++ b/src/services/municipalities.js
@@ -63,4 +63,43 @@ const getAll = async(search, limit = 15) => {
   return { municipalities: rows };
 };
 
-module.exports = { getMunicipalitiesByStateId, getMunicipality, getAll };
+const addMunicipality = async(body) => {
+  const { name } = body;
+  // eslint-disable-next-line camelcase
+  const state_id = body.state_id;
+  const key = name.toLowerCase().replace(/ /g, '_');
+  // eslint-disable-next-line camelcase
+  const result = await municipalities.create({ key, name, state_id, active: true });
+  return result;
+};
+
+const updateMunicipality = async(id, body) => {
+  const { name } = body;
+  // eslint-disable-next-line camelcase
+  const state_id = body.state_id;
+  const data = await municipalities.findByPk(id);
+
+  if (!data) {
+    return null;
+  }
+
+  data.name = name;
+  // eslint-disable-next-line camelcase
+  data.state_id = state_id;
+
+  const result = await data.save();
+  return result;
+};
+
+const deleteMunicipality = async(id) => {
+  const data = await municipalities.findByPk(id);
+
+  if (!data) {
+    return null;
+  }
+
+  await data.destroy();
+  return data;
+};
+
+module.exports = { getMunicipalitiesByStateId, getMunicipality, getAll, addMunicipality, updateMunicipality, deleteMunicipality };

--- a/src/tests/05_municipalities.test.js
+++ b/src/tests/05_municipalities.test.js
@@ -219,6 +219,284 @@ describe('[MUNICIPALITIES] Test api municipalities //api/municipalities/', () =>
   });
 
   // ============================================
+  // Tests CRUD: POST /municipalities
+  // ============================================
+  describe('POST /municipalities - Crear municipio', () => {
+    test('C1. POST cuerpo valido. Expect 201 con active:true', async() => {
+      const response = await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Municipio Test CRUD', state_id: 1 })
+        .expect(201);
+
+      expect(response.body).toHaveProperty('municipality');
+      expect(response.body.municipality).toHaveProperty('id');
+      expect(response.body.municipality.name).toBe('Municipio Test CRUD');
+      expect(response.body.municipality.active).toBe(true);
+      expect(response.body.municipality.state_id).toBe(1);
+    });
+
+    test('C2. POST sin nombre. Expect 400', async() => {
+      await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ state_id: 1 })
+        .expect(400);
+    });
+
+    test('C3. POST sin state_id. Expect 400', async() => {
+      await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Test Sin Estado' })
+        .expect(400);
+    });
+
+    test('C4. POST con state_id no entero. Expect 400', async() => {
+      await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Test', state_id: 'abc' })
+        .expect(400);
+    });
+
+    test('C5. POST sin autenticacion. Expect 401', async() => {
+      await api
+        .post('/api/municipalities')
+        .send({ name: 'Test', state_id: 1 })
+        .expect(401);
+    });
+
+    test('C6. POST sin privilegio create_municipality. Expect 403', async() => {
+      // Crear usuario sin privilegios
+      const superadminLoginRes = await api
+        .post('/api/auth/login')
+        .send({ email: 'superadmin@estelaris.com', password: 'Admin123' });
+      const superadminToken = superadminLoginRes.body.sesion.token;
+
+      const newUserEmail = `mun_crud_nopriv_${Date.now()}@test.com`;
+      const registerRes = await api
+        .post('/api/auth/register')
+        .auth(superadminToken, { type: 'bearer' })
+        .send({
+          name: 'Sin Priv Municipio CRUD',
+          email: newUserEmail,
+          password: 'Test1234',
+          role: 'user'
+        });
+
+      if (registerRes.status !== 200) {
+        expect(true).toBe(true);
+        return;
+      }
+
+      const loginRes = await api
+        .post('/api/auth/login')
+        .send({ email: newUserEmail, password: 'Test1234' });
+
+      const noPrivToken = loginRes.body.sesion.token;
+
+      await api
+        .post('/api/municipalities')
+        .auth(noPrivToken, { type: 'bearer' })
+        .send({ name: 'Test', state_id: 1 })
+        .expect(403);
+    });
+  });
+
+  // ============================================
+  // Tests CRUD: PUT /municipalities/:id
+  // ============================================
+  describe('PUT /municipalities/:id - Actualizar municipio', () => {
+    let municipalityToUpdateId = null;
+
+    test('U1. Crear municipio para update', async() => {
+      const response = await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Mun Para Update', state_id: 2 })
+        .expect(201);
+
+      municipalityToUpdateId = response.body.municipality.id;
+      expect(municipalityToUpdateId).toBeDefined();
+    });
+
+    test('U2. PUT valido. Expect 200 con datos actualizados', async() => {
+      const response = await api
+        .put(`/api/municipalities/${municipalityToUpdateId}`)
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Mun Actualizado', state_id: 3 })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('municipality');
+      expect(response.body.municipality.name).toBe('Mun Actualizado');
+      expect(response.body.municipality.state_id).toBe(3);
+    });
+
+    test('U3. PUT con id no numerico. Expect 400', async() => {
+      await api
+        .put('/api/municipalities/abc')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Test', state_id: 1 })
+        .expect(400);
+    });
+
+    test('U4. PUT sin nombre. Expect 400', async() => {
+      await api
+        .put(`/api/municipalities/${municipalityToUpdateId}`)
+        .auth(Token, { type: 'bearer' })
+        .send({ state_id: 1 })
+        .expect(400);
+    });
+
+    test('U5. PUT sin state_id. Expect 400', async() => {
+      await api
+        .put(`/api/municipalities/${municipalityToUpdateId}`)
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Nombre Valido' })
+        .expect(400);
+    });
+
+    test('U6. PUT id inexistente. Expect 404', async() => {
+      await api
+        .put('/api/municipalities/99999')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Nombre Valido', state_id: 1 })
+        .expect(404);
+    });
+
+    test('U7. PUT sin autenticacion. Expect 401', async() => {
+      await api
+        .put(`/api/municipalities/${municipalityToUpdateId}`)
+        .send({ name: 'Test', state_id: 1 })
+        .expect(401);
+    });
+
+    test('U8. PUT sin privilegio update_municipality. Expect 403', async() => {
+      const superadminLoginRes = await api
+        .post('/api/auth/login')
+        .send({ email: 'superadmin@estelaris.com', password: 'Admin123' });
+      const superadminToken = superadminLoginRes.body.sesion.token;
+
+      const newUserEmail = `mun_upd_nopriv_${Date.now()}@test.com`;
+      const registerRes = await api
+        .post('/api/auth/register')
+        .auth(superadminToken, { type: 'bearer' })
+        .send({
+          name: 'Sin Priv Update',
+          email: newUserEmail,
+          password: 'Test1234',
+          role: 'user'
+        });
+
+      if (registerRes.status !== 200) {
+        expect(true).toBe(true);
+        return;
+      }
+
+      const loginRes = await api
+        .post('/api/auth/login')
+        .send({ email: newUserEmail, password: 'Test1234' });
+
+      const noPrivToken = loginRes.body.sesion.token;
+
+      await api
+        .put(`/api/municipalities/${municipalityToUpdateId}`)
+        .auth(noPrivToken, { type: 'bearer' })
+        .send({ name: 'Test', state_id: 1 })
+        .expect(403);
+    });
+  });
+
+  // ============================================
+  // Tests CRUD: DELETE /municipalities/:id
+  // ============================================
+  describe('DELETE /municipalities/:id - Eliminar municipio', () => {
+    let municipalityToDeleteId = null;
+
+    test('D1. Crear municipio para delete', async() => {
+      const response = await api
+        .post('/api/municipalities')
+        .auth(Token, { type: 'bearer' })
+        .send({ name: 'Mun Para Delete', state_id: 1 })
+        .expect(201);
+
+      municipalityToDeleteId = response.body.municipality.id;
+      expect(municipalityToDeleteId).toBeDefined();
+    });
+
+    test('D2. DELETE con id no numerico. Expect 400', async() => {
+      await api
+        .delete('/api/municipalities/xyz')
+        .auth(Token, { type: 'bearer' })
+        .expect(400);
+    });
+
+    test('D3. DELETE id inexistente. Expect 404', async() => {
+      await api
+        .delete('/api/municipalities/99999')
+        .auth(Token, { type: 'bearer' })
+        .expect(404);
+    });
+
+    test('D4. DELETE sin autenticacion. Expect 401', async() => {
+      await api
+        .delete(`/api/municipalities/${municipalityToDeleteId}`)
+        .expect(401);
+    });
+
+    test('D5. DELETE sin privilegio delete_municipality. Expect 403', async() => {
+      const superadminLoginRes = await api
+        .post('/api/auth/login')
+        .send({ email: 'superadmin@estelaris.com', password: 'Admin123' });
+      const superadminToken = superadminLoginRes.body.sesion.token;
+
+      const newUserEmail = `mun_del_nopriv_${Date.now()}@test.com`;
+      const registerRes = await api
+        .post('/api/auth/register')
+        .auth(superadminToken, { type: 'bearer' })
+        .send({
+          name: 'Sin Priv Delete',
+          email: newUserEmail,
+          password: 'Test1234',
+          role: 'user'
+        });
+
+      if (registerRes.status !== 200) {
+        expect(true).toBe(true);
+        return;
+      }
+
+      const loginRes = await api
+        .post('/api/auth/login')
+        .send({ email: newUserEmail, password: 'Test1234' });
+
+      const noPrivToken = loginRes.body.sesion.token;
+
+      await api
+        .delete(`/api/municipalities/${municipalityToDeleteId}`)
+        .auth(noPrivToken, { type: 'bearer' })
+        .expect(403);
+    });
+
+    test('D6. DELETE valido (soft delete). Expect 200', async() => {
+      const response = await api
+        .delete(`/api/municipalities/${municipalityToDeleteId}`)
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('result');
+    });
+
+    test('D7. Re-fetch municipio eliminado. Expect 404', async() => {
+      await api
+        .get(`/api/municipalities/${municipalityToDeleteId}`)
+        .auth(Token, { type: 'bearer' })
+        .expect(404);
+    });
+  });
+
+  // ============================================
   // Tests de estructura de respuesta
   // ============================================
   describe('Tests de estructura de respuesta', () => {

--- a/src/tests/unit/municipalities.service.test.js
+++ b/src/tests/unit/municipalities.service.test.js
@@ -3,7 +3,10 @@ const { municipalities, states } = require('../../models/index');
 const {
   getMunicipalitiesByStateId,
   getMunicipality,
-  getAll
+  getAll,
+  addMunicipality,
+  updateMunicipality,
+  deleteMunicipality
 } = require('../../services/municipalities');
 
 // Mock de los modelos
@@ -11,7 +14,9 @@ jest.mock('../../models/index', () => ({
   municipalities: {
     findAll: jest.fn(),
     findAndCountAll: jest.fn(),
-    findOne: jest.fn()
+    findOne: jest.fn(),
+    create: jest.fn(),
+    findByPk: jest.fn()
   },
   states: {}
 }));
@@ -634,6 +639,162 @@ describe('Municipalities Service - Unit Tests', () => {
           ]
         })
       );
+    });
+  });
+
+  // ============================================
+  // Tests para addMunicipality
+  // ============================================
+  describe('addMunicipality', () => {
+    test('2.1 debe llamar create con active:true y key derivado del nombre', async() => {
+      const mockResult = {
+        id: 100,
+        name: 'San Juan',
+        key: 'san_juan',
+        state_id: 14,
+        active: true
+      };
+      municipalities.create.mockResolvedValue(mockResult);
+
+      const result = await addMunicipality({ name: 'San Juan', state_id: 14 });
+
+      expect(municipalities.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'San Juan',
+          state_id: 14,
+          active: true,
+          key: 'san_juan'
+        })
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    test('debe derivar key con espacios convertidos a guiones bajos', async() => {
+      const mockResult = { id: 101, name: 'La Paz Norte', key: 'la_paz_norte', state_id: 3, active: true };
+      municipalities.create.mockResolvedValue(mockResult);
+
+      await addMunicipality({ name: 'La Paz Norte', state_id: 3 });
+
+      expect(municipalities.create).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'la_paz_norte' })
+      );
+    });
+
+    test('debe derivar key en minusculas', async() => {
+      const mockResult = { id: 102, name: 'GUANAJUATO', key: 'guanajuato', state_id: 11, active: true };
+      municipalities.create.mockResolvedValue(mockResult);
+
+      await addMunicipality({ name: 'GUANAJUATO', state_id: 11 });
+
+      expect(municipalities.create).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'guanajuato' })
+      );
+    });
+
+    test('debe propagar error si create falla', async() => {
+      municipalities.create.mockRejectedValue(new Error('DB create error'));
+
+      await expect(addMunicipality({ name: 'X', state_id: 1 })).rejects.toThrow('DB create error');
+    });
+  });
+
+  // ============================================
+  // Tests para updateMunicipality
+  // ============================================
+  describe('updateMunicipality', () => {
+    test('2.2 debe retornar null si findByPk retorna null (no encontrado)', async() => {
+      municipalities.findByPk.mockResolvedValue(null);
+
+      const result = await updateMunicipality(99999, { name: 'Nuevo Nombre', state_id: 1 });
+
+      expect(municipalities.findByPk).toHaveBeenCalledWith(99999);
+      expect(result).toBeNull();
+    });
+
+    test('debe llamar save() y retornar el registro actualizado', async() => {
+      const mockInstance = {
+        id: 5,
+        name: 'Viejo Nombre',
+        state_id: 10,
+        save: jest.fn().mockResolvedValue({ id: 5, name: 'Nuevo Nombre', state_id: 12 })
+      };
+      municipalities.findByPk.mockResolvedValue(mockInstance);
+
+      const result = await updateMunicipality(5, { name: 'Nuevo Nombre', state_id: 12 });
+
+      expect(mockInstance.name).toBe('Nuevo Nombre');
+      expect(mockInstance.state_id).toBe(12);
+      expect(mockInstance.save).toHaveBeenCalledTimes(1);
+      expect(result).toBeDefined();
+    });
+
+    test('no debe modificar key ni active al actualizar', async() => {
+      const mockInstance = {
+        id: 5,
+        name: 'Original',
+        state_id: 1,
+        key: 'original',
+        active: true,
+        save: jest.fn().mockResolvedValue({})
+      };
+      municipalities.findByPk.mockResolvedValue(mockInstance);
+
+      await updateMunicipality(5, { name: 'Modificado', state_id: 2 });
+
+      expect(mockInstance.key).toBe('original');
+      expect(mockInstance.active).toBe(true);
+    });
+
+    test('debe propagar error si save() falla', async() => {
+      const mockInstance = {
+        id: 5,
+        name: 'X',
+        state_id: 1,
+        save: jest.fn().mockRejectedValue(new Error('Save failed'))
+      };
+      municipalities.findByPk.mockResolvedValue(mockInstance);
+
+      await expect(updateMunicipality(5, { name: 'Y', state_id: 2 })).rejects.toThrow('Save failed');
+    });
+  });
+
+  // ============================================
+  // Tests para deleteMunicipality
+  // ============================================
+  describe('deleteMunicipality', () => {
+    test('2.3 debe llamar destroy() en la instancia y retornar el registro', async() => {
+      const mockInstance = {
+        id: 3,
+        name: 'A Borrar',
+        destroy: jest.fn().mockResolvedValue()
+      };
+      municipalities.findByPk.mockResolvedValue(mockInstance);
+
+      const result = await deleteMunicipality(3);
+
+      expect(municipalities.findByPk).toHaveBeenCalledWith(3);
+      expect(mockInstance.destroy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockInstance);
+    });
+
+    test('debe retornar null si findByPk retorna null (no encontrado)', async() => {
+      municipalities.findByPk.mockResolvedValue(null);
+
+      const result = await deleteMunicipality(99999);
+
+      expect(municipalities.findByPk).toHaveBeenCalledWith(99999);
+      expect(result).toBeNull();
+    });
+
+    test('debe propagar error si destroy() falla', async() => {
+      const mockInstance = {
+        id: 3,
+        name: 'X',
+        destroy: jest.fn().mockRejectedValue(new Error('Destroy failed'))
+      };
+      municipalities.findByPk.mockResolvedValue(mockInstance);
+
+      await expect(deleteMunicipality(3)).rejects.toThrow('Destroy failed');
     });
   });
 

--- a/src/validators/municipalities.js
+++ b/src/validators/municipalities.js
@@ -38,4 +38,46 @@ const validateGetAll = [
   }
 ];
 
-module.exports = { validateGetRecord, validateGetRecordByState, validateGetAll };
+const valiAddRecord = [
+  check('name')
+    .exists().withMessage('NAME_NOT_EXISTS').bail()
+    .notEmpty().withMessage('NAME_IS_EMPTY').bail()
+    .isString().withMessage('NAME_MUST_BE_STRING'),
+  check('state_id')
+    .exists().withMessage('STATE_ID_NOT_EXISTS').bail()
+    .notEmpty().withMessage('STATE_ID_IS_EMPTY').bail()
+    .isInt().withMessage('STATE_ID_MUST_BE_INT').toInt(),
+  (req, res, next) => {
+    return validateResults(req, res, next);
+  }
+];
+
+const valiUpdateRecord = [
+  check('id')
+    .exists().withMessage('ID_NOT_EXISTS').bail()
+    .notEmpty().withMessage('ID_IS_EMPTY').bail()
+    .isInt().withMessage('ID_MUST_BE_INT').toInt(),
+  check('name')
+    .exists().withMessage('NAME_NOT_EXISTS').bail()
+    .notEmpty().withMessage('NAME_IS_EMPTY').bail()
+    .isString().withMessage('NAME_MUST_BE_STRING'),
+  check('state_id')
+    .exists().withMessage('STATE_ID_NOT_EXISTS').bail()
+    .notEmpty().withMessage('STATE_ID_IS_EMPTY').bail()
+    .isInt().withMessage('STATE_ID_MUST_BE_INT').toInt(),
+  (req, res, next) => {
+    return validateResults(req, res, next);
+  }
+];
+
+const validateDeleteRecord = [
+  check('id')
+    .exists().withMessage('ID_NOT_EXISTS').bail()
+    .notEmpty().withMessage('ID_IS_EMPTY').bail()
+    .isInt().withMessage('ID_MUST_BE_INT').toInt(),
+  (req, res, next) => {
+    return validateResults(req, res, next);
+  }
+];
+
+module.exports = { validateGetRecord, validateGetRecordByState, validateGetAll, valiAddRecord, valiUpdateRecord, validateDeleteRecord };


### PR DESCRIPTION
## Summary

- Agrega `POST /api/municipalities` para crear municipios (`name` + `state_id` requeridos; `key` se deriva del `name` en el servicio; `active` siempre `true`)
- Agrega `PUT /api/municipalities/:id` para actualizar nombre y estado (`key` y `active` son inmutables)
- Agrega `DELETE /api/municipalities/:id` para borrado suave (soft delete via `paranoid: true`)
- Corrige bug en seeder: `codeName: MUN.NAME_VIEW_STATE` → `MUN.VIEW_STATE` (línea 16 en privileges.js)

## Changes

| File | Change |
|------|--------|
| `src/constants/modules.js` | ADD, UPDATE, DELETE constants added to MUNICIPALITIES |
| `src/validators/municipalities.js` | valiAddRecord, valiUpdateRecord, validateDeleteRecord |
| `src/services/municipalities.js` | addMunicipality, updateMunicipality, deleteMunicipality |
| `src/controllers/municipalities.js` | addRecord, updateRecord, deleteRecord |
| `src/routes/municipalities.js` | POST /, PUT /:id, DELETE /:id with JSDoc/Swagger |
| `src/database/seeders/json_files/privileges.js` | 3 new privileges + seeder bug fix |
| `src/tests/05_municipalities.test.js` | 21 integration tests |
| `src/tests/unit/municipalities.service.test.js` | 11 unit tests |

## Test Plan

- [x] 57 test suites, 1384 tests — all GREEN
- [x] `pnpm run lint` — clean
- [x] Strict TDD: unit tests written RED → GREEN before each service function
- [x] Integration tests cover 201/400/401/403/404 scenarios per endpoint

## Notes

- `state_id` is a `belongsTo` FK not present in `model.init()` — declared explicitly in all write validators to prevent `matchedData()` from stripping it silently
- DELETE uses `instance.destroy()` (not `destroy({where})`) to respect `paranoid: true` semantics