### PR TITLE
feat(municipalities): add search param to GET /municipalities/state/:stateId

### DIFF
--- a/src/controllers/municipalities.js
+++ b/src/controllers/municipalities.js
@@ -28,10 +28,10 @@ const getById = async(req, res) => {
 const getByStateId = async(req, res) => {
   try {
     const data = matchedData(req);
-    const { stateId } = data;
+    const { stateId, search } = data;
     const { page, limit } = getPaginationParams(data);
 
-    const { municipalities, total } = await getMunicipalitiesByStateId(stateId, page, limit);
+    const { municipalities, total } = await getMunicipalitiesByStateId(stateId, page, limit, search);
 
     res.send(buildPaginationResponse('municipalities', municipalities, total, page, limit));
   } catch (error) {

--- a/src/routes/municipalities.js
+++ b/src/routes/municipalities.js
@@ -125,6 +125,11 @@ router.get('/:id', [
 *          maximum: 100
 *          default: 20
 *        description: Registros por página
+*      - in: query
+*        name: search
+*        schema:
+*          type: string
+*        description: Filtra municipios cuyo nombre contenga el texto (opcional)
 *      responses:
 *        '200':
 *          description: Lista de municipios del estado paginada

--- a/src/services/municipalities.js
+++ b/src/services/municipalities.js
@@ -4,13 +4,15 @@ const { municipalities, states } = require('../models/index');
 const attributes = ['id', 'name', 'created_at', 'updated_at'];
 const stateAttributes = ['id', 'name'];
 
-const getMunicipalitiesByStateId = async(stateId, page = 1, limit = 20) => {
+const getMunicipalitiesByStateId = async(stateId, page = 1, limit = 20, search = '') => {
   const offset = (page - 1) * limit;
+  // eslint-disable-next-line camelcase
+  const where = { state_id: stateId };
+  if (search) where.name = { [Op.like]: `%${search}%` };
+
   const { count, rows } = await municipalities.findAndCountAll({
     attributes,
-    where: {
-      state_id: stateId
-    },
+    where,
     include: [
       {
         model: states,

--- a/src/tests/05_municipalities.test.js
+++ b/src/tests/05_municipalities.test.js
@@ -70,6 +70,41 @@ describe('[MUNICIPALITIES] Test api municipalities //api/municipalities/', () =>
     expect(response.body.municipalities.length).toBe(0);
   });
 
+  test('4b. Buscar municipios por estado con search. Expect 200', async() => {
+    const response = await api
+      .get('/api/municipalities/state/1?search=a')
+      .auth(Token, { type: 'bearer' })
+      .expect(200);
+
+    expect(response.body).toHaveProperty('municipalities');
+    expect(Array.isArray(response.body.municipalities)).toBe(true);
+    expect(response.body).toHaveProperty('pagination');
+  });
+
+  test('4c. Buscar municipios por estado sin resultados. Expect 200 con array vacio', async() => {
+    const response = await api
+      .get('/api/municipalities/state/1?search=xxxxxxxxxnotfound')
+      .auth(Token, { type: 'bearer' })
+      .expect(200);
+
+    expect(response.body.municipalities.length).toBe(0);
+    expect(response.body.pagination.total).toBe(0);
+  });
+
+  test('4d. Buscar sin search retorna todos (comportamiento previo). Expect 200', async() => {
+    const withSearch = await api
+      .get('/api/municipalities/state/1?search=')
+      .auth(Token, { type: 'bearer' })
+      .expect(200);
+
+    const withoutSearch = await api
+      .get('/api/municipalities/state/1')
+      .auth(Token, { type: 'bearer' })
+      .expect(200);
+
+    expect(withSearch.body.pagination.total).toBe(withoutSearch.body.pagination.total);
+  });
+
   // ============================================
   // Tests de autenticación
   // ============================================

--- a/src/validators/municipalities.js
+++ b/src/validators/municipalities.js
@@ -18,6 +18,7 @@ const validateGetRecordByState = [
     .exists().withMessage(MUNICIPALITY_VALIDATORS.STATE_NOT_EXISTS).bail()
     .notEmpty().withMessage(MUNICIPALITY_VALIDATORS.STATE_IS_EMPTY).bail(),
   ...paginationChecks,
+  check('search').optional().isString().trim(),
   (req, res, next) => {
     return validateResults(req, res, next);
   }


### PR DESCRIPTION
Closes #129

## Summary

- Agrega query param opcional `search` a `GET /api/municipalities/state/:stateId`
- Filtra municipios cuyo nombre contenga el texto (`Op.like %search%`)
- `pagination.total` refleja el conteo filtrado
- Sin `search` (o vacío) → retorna todos los municipios del estado (comportamiento previo intacto)

## Changes

| File | Change |
|------|--------|
| `src/validators/municipalities.js` | `search` optional en `validateGetRecordByState` |
| `src/services/municipalities.js` | `search` param en `getMunicipalitiesByStateId`, where condicional con `Op.like` |
| `src/controllers/municipalities.js` | Extrae `search` de `matchedData` y lo pasa al servicio |
| `src/routes/municipalities.js` | Documenta `search` en Swagger |
| `src/tests/05_municipalities.test.js` | 3 nuevos tests: con resultados, sin resultados, sin search |

## Test Plan

- [x] 57 test suites, 1355 tests — all GREEN
- [x] `pnpm run lint` — clean
- [x] `GET /state/:stateId?search=a` retorna solo municipios que contienen "a"
- [x] `GET /state/:stateId?search=xxxxxxxxxnotfound` retorna array vacío con `pagination.total = 0`
- [x] `GET /state/:stateId` sin search retorna mismo total que con `search=` vacío