### PR TITLE
feat(employees): add active filter param to GET endpoints

### DIFF
--- a/src/controllers/employees.js
+++ b/src/controllers/employees.js
@@ -14,7 +14,8 @@ const getRecords = async(req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { employees, total } = await getAllEmployees(req.branchId, page, limit, search);
+    const active = data.active ?? null;
+    const { employees, total } = await getAllEmployees(req.branchId, page, limit, search, active);
     res.send(buildPaginationResponse('employees', employees, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS -> ${error}`);
@@ -53,7 +54,8 @@ const getRecordsByBranch = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { employees, total } = await getEmployeesByBranch(data.branch_id, page, limit, search);
+    const active = data.active ?? null;
+    const { employees, total } = await getEmployeesByBranch(data.branch_id, page, limit, search, active);
     res.send(buildPaginationResponse('employees', employees, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_BRANCH -> ${error}`);

--- a/src/routes/employees.js
+++ b/src/routes/employees.js
@@ -43,6 +43,11 @@ const { ROLE } = require('../constants/roles');
  *          schema:
  *            type: string
  *          description: Texto para filtrar resultados
+ *        - in: query
+ *          name: active
+ *          schema:
+ *            type: boolean
+ *          description: Filtrar por estado activo/inactivo. Omitir para obtener todos.
  *      responses:
  *        '200':
  *          description: Lista de empleados paginada
@@ -186,6 +191,11 @@ router.delete('/:id/revoke-access', [
  *        schema:
  *          type: string
  *        description: Texto para filtrar resultados
+ *      - in: query
+ *        name: active
+ *        schema:
+ *          type: boolean
+ *        description: Filtrar por estado activo/inactivo. Omitir para obtener todos.
  *      responses:
  *        '200':
  *          description: Lista de empleados de la sucursal paginada

--- a/src/services/employees.js
+++ b/src/services/employees.js
@@ -7,10 +7,11 @@ const attributes = ['id', 'name', 'email', 'phone', 'hire_date', 'active', 'user
 const positionAttributes = ['id', 'name'];
 const branchAttributes = ['id', 'name'];
 
-const getAllEmployees = async (branchId = null, page = 1, limit = 20, search = '') => {
+const getAllEmployees = async (branchId = null, page = 1, limit = 20, search = '', active = null) => {
   const offset = (page - 1) * limit;
   const where = branchId !== null ? { branch_id: branchId } : {};
   if (search) where.name = { [Op.like]: `%${search}%` };
+  if (active !== null) where.active = active;
 
   const { count, rows } = await employees.findAndCountAll({
     attributes,
@@ -61,10 +62,11 @@ const getEmployee = async (id) => {
   return result;
 };
 
-const getEmployeesByBranch = async (branchId, page = 1, limit = 20, search = '') => {
+const getEmployeesByBranch = async (branchId, page = 1, limit = 20, search = '', active = null) => {
   const offset = (page - 1) * limit;
   const where = { branch_id: branchId };
   if (search) where.name = { [Op.like]: `%${search}%` };
+  if (active !== null) where.active = active;
 
   const { count, rows } = await employees.findAndCountAll({
     attributes,

--- a/src/validators/employees.js
+++ b/src/validators/employees.js
@@ -7,6 +7,7 @@ const { EMPLOYEES_VALIDATORS } = require('../constants/employees');
 const validateGetAll = [
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  check('active').optional().isBoolean().toBoolean(),
   (req, res, next) => validateResults(req, res, next)
 ];
 
@@ -26,6 +27,7 @@ const validateGetByBranch = [
     .isInt().withMessage(EMPLOYEES_VALIDATORS.BRANCH_ID_INVALID).bail(),
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  check('active').optional().isBoolean().toBoolean(),
   (req, res, next) => {
     return validateResults(req, res, next);
   }


### PR DESCRIPTION
Add optional ?active=true|false query param to GET /employees and GET /employees/branch/:branch_id. Omitting the param returns all records regardless of active state.