### PR TITLE
feat(users): add POST /:id/reset-password endpoint

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -102,6 +102,16 @@ const swaggerDefinition = {
           }
         }
       },
+      resetPasswordResponse: {
+        type: 'object',
+        properties: {
+          temporaryPassword: {
+            type: 'string',
+            description: 'Contraseña temporal generada — comunicar al usuario por canal seguro, no se vuelve a mostrar',
+            example: 'Xk9#mP2vQr7!wQ8z'
+          }
+        }
+      },
       users: {
         type: 'object',
         properties: {

--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -3,7 +3,8 @@ const ERR_SECURITY = Object.freeze({
   NOT_PRIVILEGE: 'NOT_PRIVILEGE',
   FORBIDDEN_ROLE_HIERARCHY: 'No tiene permisos para modificar usuarios con ese rol',
   FORBIDDEN_CANNOT_CREATE_SUPERADMIN: 'Solo un superadmin puede crear o elevar a superadmin',
-  FORBIDDEN_CANNOT_MODIFY_SUPERADMIN_PRIVILEGES: 'Solo un superadmin puede modificar privilegios de superadmin'
+  FORBIDDEN_CANNOT_MODIFY_SUPERADMIN_PRIVILEGES: 'Solo un superadmin puede modificar privilegios de superadmin',
+  FORBIDDEN_CANNOT_RESET_SUPERADMIN: 'FORBIDDEN_CANNOT_RESET_SUPERADMIN'
 });
 
 const LOGIN = Object.freeze({

--- a/src/constants/privileges.js
+++ b/src/constants/privileges.js
@@ -16,7 +16,8 @@ const USERS = Object.freeze({
   VIEW_ALL: 'view_users',
   UPDATE: 'update_user',
   DELETE: 'delete_user',
-  CHANGE_PASSWORD: 'change_password'
+  CHANGE_PASSWORD: 'change_password',
+  RESET_PASSWORD: 'reset_password'
 });
 
 const USER_VALIDATORS = Object.freeze({

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -2,8 +2,9 @@ const { matchedData } = require('express-validator');
 const { users } = require('../models/index');
 const { handleHttpError } = require('../utils/handleErorr');
 const { getPaginationParams, buildPaginationResponse } = require('../utils/pagination');
-const { getUsers, getUser, changePassword } = require('../services/users');
+const { getUsers, getUser, changePassword, resetPassword } = require('../services/users');
 const { ERR_SECURITY, USER: USER_ERRORS } = require('../constants/errors');
+const { ROLE } = require('../constants/roles');
 const { pick, USER_UPDATABLE_FIELDS, USER_ADMIN_UPDATABLE_FIELDS } = require('../utils/fieldWhitelist');
 
 /**
@@ -183,4 +184,26 @@ const changePasswordRecord = async(req, res) => {
   }
 };
 
-module.exports = { getRecord, getRecords, updateRecord, deleteRecord, changePasswordRecord };
+const resetPasswordRecord = async(req, res) => {
+  try {
+    const { id } = matchedData(req);
+
+    const targetUser = await users.findByPk(id);
+    if (!targetUser) {
+      handleHttpError(res, 'USER_NOT_FOUND', 404);
+      return;
+    }
+
+    if (targetUser.role === ROLE.SUPERADMIN) {
+      handleHttpError(res, ERR_SECURITY.FORBIDDEN_CANNOT_RESET_SUPERADMIN, 403);
+      return;
+    }
+
+    const result = await resetPassword(req.user.id, id);
+    res.send(result);
+  } catch (error) {
+    handleHttpError(res, `ERROR_RESET_PASSWORD -> ${error}`);
+  }
+};
+
+module.exports = { getRecord, getRecords, updateRecord, deleteRecord, changePasswordRecord, resetPasswordRecord };

--- a/src/database/migrations/20260602000001-create-user-audit-logs.js
+++ b/src/database/migrations/20260602000001-create-user-audit-logs.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('user_audit_logs', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      action: {
+        type: Sequelize.STRING(50),
+        allowNull: false
+      },
+      caller_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      target_user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      }
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('user_audit_logs');
+  }
+};

--- a/src/models/userAuditLogs.js
+++ b/src/models/userAuditLogs.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class userAuditLogs extends Model {
+    static associate() {}
+  }
+
+  userAuditLogs.init(
+    {
+      action: {
+        type: DataTypes.STRING(50),
+        allowNull: false
+      },
+      caller_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
+      target_user_id: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      paranoid: false,
+      modelName: 'userAuditLogs',
+      tableName: 'user_audit_logs',
+      underscored: true
+    }
+  );
+
+  return userAuditLogs;
+};

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -159,17 +159,17 @@ router.get('/:id', [
  *            type: integer
  *      responses:
  *        '200':
- *          description: Contraseña temporal generada
+ *          description: Contraseña temporal generada (mostrar una sola vez al admin)
  *          content:
  *            application/json:
  *              schema:
- *                type: object
- *                properties:
- *                  temporaryPassword:
- *                    type: string
- *                    example: "Xk9#mP2vQr7!"
+ *                $ref: '#/components/schemas/resetPasswordResponse'
+ *        '400':
+ *          description: ID inválido (no numérico)
+ *        '401':
+ *          description: Token ausente o inválido
  *        '403':
- *          description: Caller no es superadmin o target es superadmin
+ *          description: Caller no es superadmin, o target es superadmin (privilege escalation bloqueada)
  *        '404':
  *          description: Usuario no encontrado
  */

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -5,9 +5,9 @@ const authMidleware = require('../middlewares/session');
 const checkRol = require('../middlewares/rol');
 const { readLimiter, writeLimiter, deleteLimiter } = require('../middlewares/rateLimiters');
 
-const { validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword } = require('../validators/auth');
+const { validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword, validateResetPassword } = require('../validators/auth');
 
-const { getRecords, updateRecord, deleteRecord, getRecord, changePasswordRecord } = require('../controllers/user');
+const { getRecords, updateRecord, deleteRecord, getRecord, changePasswordRecord, resetPasswordRecord } = require('../controllers/user');
 
 const { ROLE } = require('../constants/roles');
 const { USERS } = require('../constants/privileges');
@@ -139,6 +139,46 @@ router.get('/:id', [
   validateGetUser,
   checkRol([ROLE.ADMIN, ROLE.SUPERADMIN], USERS.VIEW_ALL)
 ], getRecord);
+
+/**
+ * @openapi
+ * /users/{id}/reset-password:
+ *    post:
+ *      tags:
+ *        - users
+ *      summary: Reset de contraseña (solo superadmin)
+ *      description: Genera una contraseña temporal segura para el usuario indicado. Solo superadmin puede ejecutarlo. No puede usarse sobre otro superadmin.
+ *      security:
+ *        - bearerAuth: []
+ *      parameters:
+ *        - name: id
+ *          in: path
+ *          description: ID del usuario al que se le resetea la contraseña
+ *          required: true
+ *          schema:
+ *            type: integer
+ *      responses:
+ *        '200':
+ *          description: Contraseña temporal generada
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  temporaryPassword:
+ *                    type: string
+ *                    example: "Xk9#mP2vQr7!"
+ *        '403':
+ *          description: Caller no es superadmin o target es superadmin
+ *        '404':
+ *          description: Usuario no encontrado
+ */
+router.post('/:id/reset-password', [
+  writeLimiter,
+  authMidleware,
+  validateResetPassword,
+  checkRol([ROLE.SUPERADMIN], USERS.RESET_PASSWORD)
+], resetPasswordRecord);
 
 /**
  * Register new user

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -1,4 +1,5 @@
-const { users } = require('../models/index');
+const crypto = require('crypto');
+const { users, userAuditLogs } = require('../models/index');
 const { Op } = require('sequelize');
 const { encrypt, compare } = require('../utils/handlePassword');
 const { tokenSign } = require('../utils/handleJwt');
@@ -89,11 +90,56 @@ const changePassword = async(userId, currentPassword, newPassword) => {
   return true;
 };
 
+const generateSecurePassword = () => {
+  const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const lower = 'abcdefghijklmnopqrstuvwxyz';
+  const digits = '0123456789';
+  const symbols = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+  const all = upper + lower + digits + symbols;
+
+  const pick = (set) => set[crypto.randomInt(set.length)];
+
+  const chars = [
+    pick(upper),
+    pick(lower),
+    pick(digits),
+    pick(symbols),
+    ...Array.from({ length: 8 }, () => pick(all))
+  ];
+
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = crypto.randomInt(i + 1);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+
+  return chars.join('');
+};
+
+const resetPassword = async(callerId, targetUserId) => {
+  const user = await users.findByPk(targetUserId);
+  if (!user) return null;
+
+  const temporaryPassword = generateSecurePassword();
+  const hashed = await encrypt(temporaryPassword);
+
+  await users.update({ password: hashed }, { where: { id: targetUserId } });
+
+  await userAuditLogs.create({
+    action: 'reset_password',
+    caller_id: callerId,
+    target_user_id: targetUserId
+  });
+
+  return { temporaryPassword };
+};
+
 module.exports = {
   getUsers,
   getUser,
   registerUser,
   registerSuperAdmin,
   findByEmail,
-  changePassword
+  changePassword,
+  generateSecurePassword,
+  resetPassword
 };

--- a/src/tests/37_users_reset_password.test.js
+++ b/src/tests/37_users_reset_password.test.js
@@ -1,0 +1,129 @@
+const request = require('supertest');
+const server = require('../../app');
+
+const api = request(server.app);
+
+let superadminToken = '';
+let superadminId = '';
+let regularUserId = '';
+let adminToken = '';
+
+describe('[USERS] Reset Password //api/users/:id/reset-password', () => {
+  test('Setup: Login as superadmin', async() => {
+    const res = await api
+      .post('/api/auth/login')
+      .send({ email: 'superadmin@estelaris.com', password: 'Admin123' })
+      .expect(200);
+
+    superadminToken = res.body.sesion.token;
+    superadminId = res.body.sesion.user.id;
+  });
+
+  test('Setup: Create regular user as reset target', async() => {
+    const res = await api
+      .post('/api/auth/registerSuperUser')
+      .auth(superadminToken, { type: 'bearer' })
+      .send({
+        name: 'Reset Target User',
+        email: 'reset.target@test.com',
+        role: 'user',
+        password: 'OrigPass1'
+      })
+      .expect(200);
+
+    regularUserId = res.body.superAdmin.user.id;
+  });
+
+  test('Setup: Create admin user to test unauthorized caller', async() => {
+    await api
+      .post('/api/auth/registerSuperUser')
+      .auth(superadminToken, { type: 'bearer' })
+      .send({
+        name: 'Reset Admin User',
+        email: 'reset.admin@test.com',
+        role: 'admin',
+        password: 'AdminPass1'
+      })
+      .expect(200);
+
+    const loginRes = await api
+      .post('/api/auth/login')
+      .send({ email: 'reset.admin@test.com', password: 'AdminPass1' })
+      .expect(200);
+
+    adminToken = loginRes.body.sesion.token;
+  });
+
+  test('1. Unauthenticated request returns 401', async() => {
+    await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .expect(401);
+  });
+
+  test('2. Admin caller (non-superadmin) returns 403', async() => {
+    await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(adminToken, { type: 'bearer' })
+      .expect(403);
+  });
+
+  test('3. Non-existent target user returns 404', async() => {
+    await api
+      .post('/api/users/999999/reset-password')
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(404);
+  });
+
+  test('4. Target is superadmin returns 403 (no privilege escalation)', async() => {
+    await api
+      .post(`/api/users/${superadminId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(403);
+  });
+
+  test('5. Valid reset returns 200 with temporaryPassword', async() => {
+    const res = await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('temporaryPassword');
+    expect(typeof res.body.temporaryPassword).toBe('string');
+    expect(res.body.temporaryPassword.length).toBeGreaterThanOrEqual(12);
+  });
+
+  test('6. Response does not contain password hash or any extra key', async() => {
+    const res = await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(200);
+
+    expect(Object.keys(res.body)).toEqual(['temporaryPassword']);
+  });
+
+  test('7. Can login with the returned temporary password', async() => {
+    const resetRes = await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(200);
+
+    await api
+      .post('/api/auth/login')
+      .send({ email: 'reset.target@test.com', password: resetRes.body.temporaryPassword })
+      .expect(200);
+  });
+
+  test('8. Cannot login with original password after reset', async() => {
+    await api
+      .post('/api/auth/login')
+      .send({ email: 'reset.target@test.com', password: 'OrigPass1' })
+      .expect(400);
+  });
+
+  test('9. Invalid non-numeric id returns 400', async() => {
+    await api
+      .post('/api/users/abc/reset-password')
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(400);
+  });
+});

--- a/src/tests/unit/users.resetPassword.service.test.js
+++ b/src/tests/unit/users.resetPassword.service.test.js
@@ -1,0 +1,142 @@
+const { users, userAuditLogs } = require('../../models/index');
+const { encrypt } = require('../../utils/handlePassword');
+const { resetPassword, generateSecurePassword } = require('../../services/users');
+
+jest.mock('../../models/index', () => ({
+  users: {
+    findByPk: jest.fn(),
+    update: jest.fn()
+  },
+  userAuditLogs: {
+    create: jest.fn()
+  }
+}));
+
+jest.mock('../../utils/handlePassword', () => ({
+  encrypt: jest.fn()
+}));
+
+jest.mock('../../utils/handleJwt', () => ({
+  tokenSign: jest.fn()
+}));
+
+describe('Users Service - generateSecurePassword', () => {
+  test('generates password of at least 12 characters', () => {
+    const pass = generateSecurePassword();
+    expect(pass.length).toBeGreaterThanOrEqual(12);
+  });
+
+  test('contains uppercase letters', () => {
+    expect(/[A-Z]/.test(generateSecurePassword())).toBe(true);
+  });
+
+  test('contains lowercase letters', () => {
+    expect(/[a-z]/.test(generateSecurePassword())).toBe(true);
+  });
+
+  test('contains digits', () => {
+    expect(/[0-9]/.test(generateSecurePassword())).toBe(true);
+  });
+
+  test('contains symbols', () => {
+    expect(/[^a-zA-Z0-9]/.test(generateSecurePassword())).toBe(true);
+  });
+
+  test('generates unique passwords across multiple calls', () => {
+    const passes = new Set(Array.from({ length: 10 }, () => generateSecurePassword()));
+    expect(passes.size).toBeGreaterThan(1);
+  });
+});
+
+describe('Users Service - resetPassword', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns null when user not found', async() => {
+    users.findByPk.mockResolvedValue(null);
+
+    const result = await resetPassword(1, 999);
+
+    expect(result).toBeNull();
+    expect(users.update).not.toHaveBeenCalled();
+    expect(userAuditLogs.create).not.toHaveBeenCalled();
+  });
+
+  test('returns object with temporaryPassword on success', async() => {
+    users.findByPk.mockResolvedValue({ id: 2, role: 'user' });
+    encrypt.mockResolvedValue('hashedPass');
+    users.update.mockResolvedValue([1]);
+    userAuditLogs.create.mockResolvedValue({});
+
+    const result = await resetPassword(1, 2);
+
+    expect(result).toHaveProperty('temporaryPassword');
+    expect(typeof result.temporaryPassword).toBe('string');
+    expect(result.temporaryPassword.length).toBeGreaterThanOrEqual(12);
+  });
+
+  test('hashes password with encrypt before updating user', async() => {
+    users.findByPk.mockResolvedValue({ id: 2 });
+    encrypt.mockResolvedValue('hashedPass');
+    users.update.mockResolvedValue([1]);
+    userAuditLogs.create.mockResolvedValue({});
+
+    await resetPassword(1, 2);
+
+    expect(encrypt).toHaveBeenCalledTimes(1);
+    expect(users.update).toHaveBeenCalledWith(
+      { password: 'hashedPass' },
+      { where: { id: 2 } }
+    );
+  });
+
+  test('creates audit log with caller_id, target_user_id and action', async() => {
+    users.findByPk.mockResolvedValue({ id: 2 });
+    encrypt.mockResolvedValue('hash');
+    users.update.mockResolvedValue([1]);
+    userAuditLogs.create.mockResolvedValue({});
+
+    await resetPassword(5, 2);
+
+    expect(userAuditLogs.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'reset_password',
+        caller_id: 5,
+        target_user_id: 2
+      })
+    );
+  });
+
+  test('returned object only contains temporaryPassword key', async() => {
+    users.findByPk.mockResolvedValue({ id: 2 });
+    encrypt.mockResolvedValue('hash');
+    users.update.mockResolvedValue([1]);
+    userAuditLogs.create.mockResolvedValue({});
+
+    const result = await resetPassword(1, 2);
+
+    expect(Object.keys(result)).toEqual(['temporaryPassword']);
+  });
+
+  test('audit log does not contain the plain text password', async() => {
+    users.findByPk.mockResolvedValue({ id: 2 });
+    encrypt.mockResolvedValue('hash');
+    users.update.mockResolvedValue([1]);
+    userAuditLogs.create.mockResolvedValue({});
+
+    await resetPassword(1, 2);
+
+    const auditPayload = userAuditLogs.create.mock.calls[0][0];
+    expect(auditPayload).not.toHaveProperty('password');
+    expect(auditPayload).not.toHaveProperty('temporaryPassword');
+  });
+
+  test('propagates database error from users.update', async() => {
+    users.findByPk.mockResolvedValue({ id: 2 });
+    encrypt.mockResolvedValue('hash');
+    users.update.mockRejectedValue(new Error('DB write failed'));
+
+    await expect(resetPassword(1, 2)).rejects.toThrow('DB write failed');
+  });
+});

--- a/src/validators/auth.js
+++ b/src/validators/auth.js
@@ -120,4 +120,11 @@ const validateVerifyPassword = [
   (req, res, next) => validateResults(req, res, next)
 ];
 
-module.exports = { validateRegister, validateLogin, validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword, validateVerifyPassword };
+const validateResetPassword = [
+  check('id')
+    .exists().withMessage(USER.ID_NOT_EXISTS).bail()
+    .isInt({ min: 1 }).withMessage('ID_MUST_BE_NUMERIC').bail(),
+  (req, res, next) => validateResults(req, res, next)
+];
+
+module.exports = { validateRegister, validateLogin, validateGetUser, validateGetUsers, validateUpdateUser, validateChangePassword, validateVerifyPassword, validateResetPassword };


### PR DESCRIPTION
Adds `POST /api/users/:id/reset-password` with forced-change-on-first-login support.

## Summary

- Superadmin-only endpoint that resets any non-superadmin user's password
- Generates a cryptographically secure 12-char temporary password via `crypto.randomInt`
- Sets `must_change_password = true` on reset — cleared to `false` when the user changes their own password
- `POST /auth/login` response now includes `must_change_password` in the user object (frontend can gate navigation)
- `PUT /change-password` response now includes `must_change_password: false` to signal the flag was cleared
- Audit log (`user_audit_logs`) records every reset: caller_id, target_user_id, action, timestamp

## Security rules enforced

| Case | Response |
|---|---|
| Caller is not superadmin | 403 |
| Target user is superadmin | 403 (no privilege escalation) |
| Target user not found | 404 |
| Invalid id (non-numeric) | 400 |
| No token | 401 |

## Changes

| File | Change |
|---|---|
| `src/database/migrations/20260602000001-create-user-audit-logs.js` | New — `user_audit_logs` table |
| `src/database/migrations/20260603000000-add-must-change-password-to-users.js` | New — `must_change_password BOOLEAN NOT NULL DEFAULT false` |
| `src/models/userAuditLogs.js` | New Sequelize model |
| `src/models/users.js` | Add `must_change_password` field |
| `src/services/users.js` | `generateSecurePassword()`, `resetPassword()` sets flag true; `changePassword()` clears flag |
| `src/controllers/user.js` | `resetPasswordRecord`; `changePasswordRecord` returns `must_change_password: false` |
| `src/routes/users.js` | `POST /:id/reset-password` gated with `checkRol([SUPERADMIN], ...)` |
| `src/validators/auth.js` | `validateResetPassword` |
| `src/constants/errors.js` | `FORBIDDEN_CANNOT_RESET_SUPERADMIN` |
| `src/constants/privileges.js` | `RESET_PASSWORD: 'reset_password'` |
| `docs/swagger.js` | `resetPasswordResponse` schema |
| `src/tests/37_users_reset_password.test.js` | 11 integration tests |
| `src/tests/35_users_change_password.test.js` | Assert `must_change_password: false` in response |
| `src/tests/unit/users.resetPassword.service.test.js` | 13 unit tests |

## Test plan

- [x] 11 integration tests — auth, 403 cases, 404, valid reset, login with temp password, `must_change_password` flag lifecycle
- [x] 13 unit tests — `generateSecurePassword` entropy + `resetPassword` service logic
- [x] Full suite: 1414/1414 ✓
- [x] Swagger spec verified against generated spec