### PR TITLE
feat(users): add must_change_password flag for forced password change…

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -178,7 +178,7 @@ const changePasswordRecord = async(req, res) => {
       return;
     }
 
-    res.send({ message: 'PASSWORD_CHANGED_SUCCESSFULLY' });
+    res.send({ message: 'PASSWORD_CHANGED_SUCCESSFULLY', must_change_password: false });
   } catch (error) {
     handleHttpError(res, `ERROR_CHANGE_PASSWORD -> ${error}`, 400);
   }

--- a/src/database/migrations/20260603000000-add-must-change-password-to-users.js
+++ b/src/database/migrations/20260603000000-add-must-change-password-to-users.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'must_change_password', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      after: 'role'
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('users', 'must_change_password');
+  }
+};

--- a/src/models/users.js
+++ b/src/models/users.js
@@ -22,7 +22,11 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING,
     email: DataTypes.STRING,
     password: DataTypes.STRING,
-    role: DataTypes.STRING
+    role: DataTypes.STRING,
+    must_change_password: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false
+    }
   }, {
     sequelize,
     paranoid: true,

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -85,7 +85,7 @@ const changePassword = async(userId, currentPassword, newPassword) => {
   if (!isMatch) return false;
 
   const hashed = await encrypt(newPassword);
-  await users.update({ password: hashed }, { where: { id: userId } });
+  await users.update({ password: hashed, must_change_password: false }, { where: { id: userId } });
 
   return true;
 };
@@ -122,7 +122,7 @@ const resetPassword = async(callerId, targetUserId) => {
   const temporaryPassword = generateSecurePassword();
   const hashed = await encrypt(temporaryPassword);
 
-  await users.update({ password: hashed }, { where: { id: targetUserId } });
+  await users.update({ password: hashed, must_change_password: true }, { where: { id: targetUserId } });
 
   await userAuditLogs.create({
     action: 'reset_password',

--- a/src/tests/35_users_change_password.test.js
+++ b/src/tests/35_users_change_password.test.js
@@ -96,6 +96,7 @@ describe('[USERS] Change password //api/users/change-password', () => {
       .expect(200);
 
     expect(res.body.message).toBe('PASSWORD_CHANGED_SUCCESSFULLY');
+    expect(res.body.must_change_password).toBe(false);
   });
 
   test('6. Login with old password fails after change', async() => {

--- a/src/tests/37_users_reset_password.test.js
+++ b/src/tests/37_users_reset_password.test.js
@@ -126,4 +126,52 @@ describe('[USERS] Reset Password //api/users/:id/reset-password', () => {
       .auth(superadminToken, { type: 'bearer' })
       .expect(400);
   });
+
+  test('10. Login after reset includes must_change_password: true', async() => {
+    const resetRes = await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(200);
+
+    const loginRes = await api
+      .post('/api/auth/login')
+      .send({ email: 'reset.target@test.com', password: resetRes.body.temporaryPassword })
+      .expect(200);
+
+    expect(loginRes.body.sesion.user.must_change_password).toBe(true);
+  });
+
+  test('11. After change-password, must_change_password resets to false', async() => {
+    const resetRes = await api
+      .post(`/api/users/${regularUserId}/reset-password`)
+      .auth(superadminToken, { type: 'bearer' })
+      .expect(200);
+
+    const tempPassword = resetRes.body.temporaryPassword;
+    const newPassword = 'Secure99!newpass';
+
+    const changeRes = await api
+      .put('/api/users/change-password')
+      .auth(
+        (await api.post('/api/auth/login')
+          .send({ email: 'reset.target@test.com', password: tempPassword })
+          .expect(200)).body.sesion.token,
+        { type: 'bearer' }
+      )
+      .send({
+        current_password: tempPassword,
+        new_password: newPassword,
+        confirm_password: newPassword
+      })
+      .expect(200);
+
+    expect(changeRes.body.must_change_password).toBe(false);
+
+    const loginAfter = await api
+      .post('/api/auth/login')
+      .send({ email: 'reset.target@test.com', password: newPassword })
+      .expect(200);
+
+    expect(loginAfter.body.sesion.user.must_change_password).toBe(false);
+  });
 });

--- a/src/tests/unit/users.resetPassword.service.test.js
+++ b/src/tests/unit/users.resetPassword.service.test.js
@@ -86,7 +86,7 @@ describe('Users Service - resetPassword', () => {
 
     expect(encrypt).toHaveBeenCalledTimes(1);
     expect(users.update).toHaveBeenCalledWith(
-      { password: 'hashedPass' },
+      { password: 'hashedPass', must_change_password: true },
       { where: { id: 2 } }
     );
   });


### PR DESCRIPTION
… on first login

- Migration: add must_change_password BOOLEAN NOT NULL DEFAULT false to users
- Model: expose must_change_password field
- reset-password: sets must_change_password=true after reset
- change-password: clears must_change_password=false + returns flag in response
- Login response includes must_change_password via model field (no controller change needed)