### PR TITLE
chore(deps): upgrade pnpm 10.33 → 11.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sistema de administracion de mercancias Estelaris",
   "main": "index.js",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.1",
   "scripts": {
     "start": "node ./app.js",
     "dev": "nodemon ./app.js",
@@ -57,10 +57,5 @@
   },
   "lint-staged": {
     "*.(js)": "eslint --fix --ignore-path .gitignore"
-  },
-  "pnpm": {
-    "overrides": {
-      "yaml@>=2.0.0 <2.8.3": ">=2.8.3"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@scarf/scarf': true
+overrides:
+  yaml@>=2.0.0 <2.8.3: ">=2.8.3"


### PR DESCRIPTION
pnpm 11 drops support for reading `pnpm.overrides` from package.json. Migrate overrides and allowBuilds config to the new pnpm-workspace.yaml file and bump the packageManager field accordingly.