### PR TITLE
feat(productStocks): add in_stock filter to GET /productStocks/branch/:branch_id

### DIFF
--- a/src/controllers/productStocks.js
+++ b/src/controllers/productStocks.js
@@ -78,7 +78,8 @@ const getRecordsByBranch = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { stocks, total } = await getStocksByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder);
+    const inStock = data.in_stock ?? null;
+    const { stocks, total } = await getStocksByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder, inStock);
     res.send(buildPaginationResponse('stocks', stocks, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_BRANCH -> ${error}`, 400);

--- a/src/database/seeders/test_files/20260123200001-product-stocks.js
+++ b/src/database/seeders/test_files/20260123200001-product-stocks.js
@@ -55,6 +55,19 @@ module.exports = {
         last_count_date: null,
         created_at: new Date(),
         updated_at: new Date()
+      },
+      // TEST-001 en sucursal 1 con cantidad cero (para filtro in_stock)
+      {
+        id: 5,
+        product_id: 'TEST-001',
+        branch_id: 1,
+        quantity: 0,
+        min_stock: 5,
+        max_stock: 50,
+        location: 'D-04-01',
+        last_count_date: null,
+        created_at: new Date(),
+        updated_at: new Date()
       }
     ];
 

--- a/src/routes/productStocks.js
+++ b/src/routes/productStocks.js
@@ -183,6 +183,12 @@ router.get('/product/:product_id', [
  *        schema:
  *          type: string
  *        description: Texto para filtrar resultados
+ *      - in: query
+ *        name: in_stock
+ *        required: false
+ *        schema:
+ *          type: boolean
+ *        description: Si es true, devuelve solo inventarios con cantidad mayor a cero (disponibles para venta/traspaso)
  *      responses:
  *        '200':
  *          description: Lista de inventarios de la sucursal paginada

--- a/src/services/productStocks.js
+++ b/src/services/productStocks.js
@@ -106,7 +106,7 @@ const getStocksByProduct = async (productId, page = 1, limit = 20, search = '') 
   return { stocks: rows, total: count };
 };
 
-const getStocksByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
+const getStocksByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC', inStock = null) => {
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
 
@@ -122,9 +122,12 @@ const getStocksByBranch = async (branchId, page = 1, limit = 20, search = '', so
       : {})
   };
 
+  const where = { branch_id: branchId };
+  if (inStock) where.quantity = { [Op.gt]: 0 };
+
   const { count, rows } = await productStocks.findAndCountAll({
     attributes,
-    where: { branch_id: branchId },
+    where,
     include: [productInclude],
     order: buildSortOrder(safeSortBy, safeSortOrder),
     limit,

--- a/src/tests/14_productStocks.test.js
+++ b/src/tests/14_productStocks.test.js
@@ -125,6 +125,56 @@ describe('[PRODUCT STOCKS] Test api productStocks //api/productStocks/', () => {
   });
 
   // ============================================
+  // Tests de filtro in_stock
+  // ============================================
+  describe('[in_stock filter] GET /productStocks/branch/:branch_id', () => {
+    test('A. Valor inválido in_stock=yes debe retornar 400', async () => {
+      await api
+        .get('/api/productStocks/branch/1?in_stock=yes')
+        .auth(Token, { type: 'bearer' })
+        .expect(400);
+    });
+
+    test('B. in_stock=true solo retorna stocks con quantity > 0', async () => {
+      const response = await api
+        .get('/api/productStocks/branch/1?in_stock=true')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('stocks');
+      expect(Array.isArray(response.body.stocks)).toBe(true);
+      expect(response.body.stocks.length).toBeGreaterThan(0);
+      response.body.stocks.forEach((stock) => {
+        expect(Number(stock.quantity)).toBeGreaterThan(0);
+      });
+    });
+
+    test('C. Sin parámetro retorna todos los stocks (incluyendo quantity=0)', async () => {
+      const response = await api
+        .get('/api/productStocks/branch/1')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('stocks');
+      expect(Array.isArray(response.body.stocks)).toBe(true);
+      const hasZeroStock = response.body.stocks.some((s) => Number(s.quantity) === 0);
+      expect(hasZeroStock).toBe(true);
+    });
+
+    test('D. in_stock=false incluye stocks con quantity=0', async () => {
+      const response = await api
+        .get('/api/productStocks/branch/1?in_stock=false')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('stocks');
+      expect(Array.isArray(response.body.stocks)).toBe(true);
+      const hasZeroStock = response.body.stocks.some((s) => Number(s.quantity) === 0);
+      expect(hasZeroStock).toBe(true);
+    });
+  });
+
+  // ============================================
   // Tests de autenticación
   // ============================================
   describe('Tests de autenticacion', () => {

--- a/src/tests/unit/productStocks.service.test.js
+++ b/src/tests/unit/productStocks.service.test.js
@@ -1,4 +1,5 @@
 const { productStocks, products, branches } = require('../../models/index');
+const { Op } = require('sequelize');
 const {
   getAllProductStocks,
   getStocksByProduct,
@@ -153,6 +154,23 @@ describe('ProductStocks Service - Unit Tests', () => {
 
       expect(result.stocks).toEqual([]);
       expect(result.total).toBe(0);
+    });
+
+    test('debe filtrar por cantidad mayor a cero cuando inStock=true', async () => {
+      const mockStocks = [
+        { id: 1, product_id: 'TEST-001', branch_id: 1, quantity: 100 },
+        { id: 3, product_id: 'TEST-002', branch_id: 1, quantity: 75 }
+      ];
+
+      productStocks.findAndCountAll.mockResolvedValue({ count: 2, rows: mockStocks });
+
+      await getStocksByBranch(1, 1, 20, '', 'id', 'DESC', true);
+
+      expect(productStocks.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { branch_id: 1, quantity: { [Op.gt]: 0 } }
+        })
+      );
     });
   });
 

--- a/src/validators/productStocks.js
+++ b/src/validators/productStocks.js
@@ -40,6 +40,7 @@ const validateGetByBranch = [
   ...paginationChecks,
   ...sortChecks(SORT_WHITELIST),
   check('search').optional().isString().trim(),
+  check('in_stock').optional().isBoolean().toBoolean(),
   (req, res, next) => {
     return validateResults(req, res, next);
   }


### PR DESCRIPTION
## Summary

- Agrega parámetro opcional `?in_stock=true` al endpoint `GET /api/productStocks/branch/:branch_id`
- Cuando `in_stock=true`, retorna solo registros con `quantity > 0` (uso en ventas y transferencias)
- Comportamiento sin parámetro o con `in_stock=false` permanece sin cambios (backward compatible)
- Patrón idéntico al filtro `active` del módulo `employees`

## Cambios

| Capa | Archivo | Cambio |
|------|---------|--------|
| Validator | `validators/productStocks.js` | `check('in_stock').optional().isBoolean().toBoolean()` |
| Controller | `controllers/productStocks.js` | Extrae y pasa `inStock` al service |
| Service | `services/productStocks.js` | 7mo param `inStock=null`; `if (inStock) where.quantity = { [Op.gt]: 0 }` |
| Swagger | `routes/productStocks.js` | Documenta `in_stock` como query param boolean |
| Seed test | `seeders/test_files/...product-stocks.js` | Agrega fila con `quantity: 0` para branch 1 |
| Tests | 2 archivos | +5 tests (1 unit + 4 integration) |

## Test plan

- [x] `?in_stock=true` → 200, todos los stocks retornados tienen `quantity > 0`
- [x] `?in_stock=false` → 200, incluye stocks con `quantity = 0`
- [x] Sin parámetro → 200, incluye stocks con `quantity = 0` (backward compat)
- [x] `?in_stock=yes` → 400 (valor inválido rechazado por validator)
- [x] Unit: service con `inStock=true` → `findAndCountAll` con `where.quantity = { [Op.gt]: 0 }`
- [x] `pnpm test` completo: 1419 tests, 59 suites — 0 regresiones