### PR TITLE
feat(productStocks): extend branch search to include exact bar_code match

### DIFF
--- a/src/database/seeders/test_files/20260123200001-product-stocks.js
+++ b/src/database/seeders/test_files/20260123200001-product-stocks.js
@@ -13,6 +13,7 @@ module.exports = {
         min_stock: 10,
         max_stock: 200,
         location: 'A-01-01',
+        bar_code: 'TEST-001-1',
         last_count_date: new Date(),
         created_at: new Date(),
         updated_at: new Date()

--- a/src/services/productStocks.js
+++ b/src/services/productStocks.js
@@ -114,16 +114,18 @@ const getStocksByBranch = async (branchId, page = 1, limit = 20, search = '', so
     model: products,
     as: 'product',
     attributes: productAttributes,
-    ...(search
-      ? {
-          where: { [Op.or]: [{ id: { [Op.like]: `%${search}%` } }, { name: { [Op.like]: `%${search}%` } }] },
-          required: true
-        }
-      : {})
+    required: !!search
   };
 
   const where = { branch_id: branchId };
   if (inStock) where.quantity = { [Op.gt]: 0 };
+  if (search) {
+    where[Op.or] = [
+      { bar_code: search },
+      { '$product.id$': { [Op.like]: `%${search}%` } },
+      { '$product.name$': { [Op.like]: `%${search}%` } }
+    ];
+  }
 
   const { count, rows } = await productStocks.findAndCountAll({
     attributes,

--- a/src/tests/14_productStocks.test.js
+++ b/src/tests/14_productStocks.test.js
@@ -172,6 +172,17 @@ describe('[PRODUCT STOCKS] Test api productStocks //api/productStocks/', () => {
       const hasZeroStock = response.body.stocks.some((s) => Number(s.quantity) === 0);
       expect(hasZeroStock).toBe(true);
     });
+
+    test('E. search por bar_code exacto retorna solo el stock correspondiente', async () => {
+      const response = await api
+        .get('/api/productStocks/branch/1?search=TEST-001-1')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(response.body).toHaveProperty('stocks');
+      expect(response.body.stocks.length).toBe(1);
+      expect(response.body.stocks[0].bar_code).toBe('TEST-001-1');
+    });
   });
 
   // ============================================


### PR DESCRIPTION
## Summary

- Extiende el `?search=` en `GET /api/productStocks/branch/:branch_id` para incluir `productStocks.bar_code` (match exacto) además del LIKE existente en `product.id` y `product.name`
- Sin cambios en el frontend — mismo parámetro `search`, el backend resuelve el intent automáticamente

## Motivación

El frontend puede enviar el valor exacto de un lector óptico via `?search=`. Con la implementación anterior solo se buscaba en `product.id` y `product.name` (LIKE), ignorando `bar_code`. El lector manda el valor exacto del campo `bar_code` en `productStocks`.

## Lógica del OR

```
search=TEST-001-1  →  bar_code = 'TEST-001-1'         (lector óptico, exact match)
search=silla       →  product.name LIKE '%silla%'     (búsqueda manual por nombre)
search=TEST        →  product.id   LIKE '%TEST%'      (búsqueda manual por SKU)
```

## Test plan

- [x] `?search=TEST-001-1` → 200, retorna exactamente 1 stock con `bar_code = 'TEST-001-1'`
- [x] Búsquedas LIKE por nombre/SKU existentes siguen funcionando
- [x] `pnpm test` completo: 1420 tests, 59 suites — 0 regresiones