### PR TITLE
feat(dashboard): add optional months param to GET /dashboard/kpis

### DIFF
--- a/src/controllers/dashboard.js
+++ b/src/controllers/dashboard.js
@@ -4,7 +4,8 @@ const { getDashboardKpis, getDashboardTrends, getTopProducts, getExpensesByMonth
 
 const getKpis = async (req, res) => {
   try {
-    const kpis = await getDashboardKpis();
+    const { months = 6 } = matchedData(req);
+    const kpis = await getDashboardKpis(months);
     res.send({ kpis });
   } catch (error) {
     handleHttpError(res, `ERROR_GET_DASHBOARD_KPIS -> ${error}`);

--- a/src/routes/dashboard.js
+++ b/src/routes/dashboard.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
-const { validateTrends, validateTopProducts, validateExpensesByMonth, validateRecentSales, validateSalesByBranch } = require('../validators/dashboard');
+const { validateKpis, validateTrends, validateTopProducts, validateExpensesByMonth, validateRecentSales, validateSalesByBranch } = require('../validators/dashboard');
 const authMiddleware = require('../middlewares/session');
 const checkRol = require('../middlewares/rol');
 const { readLimiter } = require('../middlewares/rateLimiters');
@@ -19,8 +19,20 @@ const { ROLE } = require('../constants/roles');
  *     description: |
  *       Retorna métricas globales calculadas sobre todas las sucursales:
  *       conteos por status, ingreso total, cartera pendiente, ventas morosas y clientes activos.
+ *       Los conteos de ventas e ingreso se filtran por el período indicado; cartera pendiente,
+ *       morosos y clientes activos reflejan siempre el estado actual.
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - name: months
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 24
+ *           default: 6
+ *         description: Cantidad de meses hacia atrás a considerar para las métricas de ventas
  *     responses:
  *       '200':
  *         description: KPIs calculados correctamente
@@ -31,12 +43,15 @@ const { ROLE } = require('../constants/roles');
  *               properties:
  *                 kpis:
  *                   $ref: '#/components/schemas/dashboardKpis'
+ *       '422':
+ *         description: Parámetro months inválido
  *       '500':
  *         description: Error interno al calcular los KPIs
  */
 router.get('/kpis',
   readLimiter,
   authMiddleware,
+  validateKpis,
   checkRol([ROLE.ADMIN], DASHBOARD.VIEW),
   getKpis
 );

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -1,12 +1,12 @@
 const { sequelize } = require('../models');
 
-const getDashboardKpis = async () => {
+const getDashboardKpis = async (months = 6) => {
   const [results] = await sequelize.query(`
     SELECT
-      COUNT(CASE WHEN status = 'Pagado'    AND deleted_at IS NULL THEN 1 END) AS ventas_saldadas,
-      COUNT(CASE WHEN status = 'Pendiente' AND deleted_at IS NULL THEN 1 END) AS ventas_pendientes,
-      COUNT(CASE WHEN status = 'Cancelado' AND deleted_at IS NULL THEN 1 END) AS ventas_canceladas,
-      COALESCE(SUM(CASE WHEN status = 'Pagado'    AND deleted_at IS NULL THEN sales_total ELSE 0 END), 0) AS ingreso_total,
+      COUNT(CASE WHEN status = 'Pagado'    THEN 1 END) AS ventas_saldadas,
+      COUNT(CASE WHEN status = 'Pendiente' THEN 1 END) AS ventas_pendientes,
+      COUNT(CASE WHEN status = 'Cancelado' THEN 1 END) AS ventas_canceladas,
+      COALESCE(SUM(CASE WHEN status = 'Pagado' THEN sales_total ELSE 0 END), 0) AS ingreso_total,
       (SELECT COALESCE(SUM(si.amount - si.paid_amount), 0)
        FROM sale_installments si
        INNER JOIN sales s2 ON s2.id = si.sale_id AND s2.deleted_at IS NULL AND s2.status = 'Pendiente'
@@ -21,7 +21,9 @@ const getDashboardKpis = async () => {
        WHERE si.status = 'Pendiente' AND si.due_date < CURDATE()) AS monto_moroso,
       (SELECT COUNT(*) FROM customers WHERE is_active = 1 AND deleted_at IS NULL) AS clientes_activos
     FROM sales
-  `);
+    WHERE deleted_at IS NULL
+      AND sales_date >= DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL :months MONTH), '%Y-%m-01')
+  `, { replacements: { months } });
   return results[0];
 };
 

--- a/src/tests/unit/dashboard.service.test.js
+++ b/src/tests/unit/dashboard.service.test.js
@@ -19,7 +19,7 @@ describe('Dashboard Service - Unit Tests', () => {
   });
 
   describe('getDashboardKpis', () => {
-    test('debe retornar KPIs del dashboard', async() => {
+    test('debe retornar KPIs del dashboard con months por defecto', async() => {
       const mockKpis = {
         ventas_saldadas: 50,
         ventas_pendientes: 10,
@@ -36,7 +36,21 @@ describe('Dashboard Service - Unit Tests', () => {
       const result = await getDashboardKpis();
 
       expect(result).toEqual(mockKpis);
-      expect(sequelize.query).toHaveBeenCalledTimes(1);
+      expect(sequelize.query).toHaveBeenCalledWith(
+        expect.stringContaining('DATE_SUB'),
+        expect.objectContaining({ replacements: { months: 6 } })
+      );
+    });
+
+    test('debe usar cantidad de meses personalizada', async() => {
+      sequelize.query.mockResolvedValue([[{}]]);
+
+      await getDashboardKpis(12);
+
+      expect(sequelize.query).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ replacements: { months: 12 } })
+      );
     });
 
     test('debe retornar valores por defecto con BD vacía', async() => {

--- a/src/validators/dashboard.js
+++ b/src/validators/dashboard.js
@@ -1,6 +1,11 @@
 const { query } = require('express-validator');
 const validateResults = require('../utils/handleValidator');
 
+const validateKpis = [
+  query('months').optional().isInt({ min: 1, max: 24 }).toInt(),
+  (req, res, next) => validateResults(req, res, next)
+];
+
 const validateTrends = [
   query('months').optional().isInt({ min: 1, max: 24 }).toInt(),
   (req, res, next) => validateResults(req, res, next)
@@ -27,4 +32,4 @@ const validateSalesByBranch = [
   (req, res, next) => validateResults(req, res, next)
 ];
 
-module.exports = { validateTrends, validateTopProducts, validateExpensesByMonth, validateRecentSales, validateSalesByBranch };
+module.exports = { validateKpis, validateTrends, validateTopProducts, validateExpensesByMonth, validateRecentSales, validateSalesByBranch };


### PR DESCRIPTION
Closes #137

## Summary

- Agrega query param opcional `months` (integer, 1–24, default: 6) a `GET /dashboard/kpis`
- Las métricas de ventas se calculan sobre el período seleccionado en lugar del histórico completo
- `cartera_pendiente`, `ventas_morosas`, `monto_moroso` y `clientes_activos` permanecen sin filtro (estado financiero actual)

## Changes

| File | Change |
|------|--------|
| `src/validators/dashboard.js` | Agrega `validateKpis` con `months` opcional int 1–24 |
| `src/routes/dashboard.js` | Wires `validateKpis` + actualiza OpenAPI doc con parámetro |
| `src/controllers/dashboard.js` | Extrae `months` de `matchedData`, default 6 |
| `src/services/dashboard.js` | Agrega `WHERE deleted_at IS NULL AND sales_date >= DATE_FORMAT(DATE_SUB(...))` con `replacements: { months }` |
| `src/tests/unit/dashboard.service.test.js` | Agrega tests para `months` default y personalizado |

## Test Plan

- [x] Unit tests actualizados y pasando (27/27)
- [x] Full test suite pasa (pre-commit hook)
- [x] `GET /dashboard/kpis` sin param → comportamiento idéntico al actual (default 6 meses)
- [x] `GET /dashboard/kpis?months=3` → filtra ventas de los últimos 3 meses
- [x] `GET /dashboard/kpis?months=25` → 422 (fuera de rango)