### PR TITLE
fix(customers): remove unique constraint from email and tax_id

### DIFF
--- a/src/database/migrations/20260611000000-remove-unique-email-taxid-customers.js
+++ b/src/database/migrations/20260611000000-remove-unique-email-taxid-customers.js
@@ -1,0 +1,21 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeConstraint('customers', 'email');
+    await queryInterface.removeConstraint('customers', 'tax_id');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addConstraint('customers', {
+      fields: ['email'],
+      type: 'unique',
+      name: 'email'
+    });
+    await queryInterface.addConstraint('customers', {
+      fields: ['tax_id'],
+      type: 'unique',
+      name: 'tax_id'
+    });
+  }
+};

--- a/src/models/customers.js
+++ b/src/models/customers.js
@@ -22,8 +22,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     email: {
       type: DataTypes.STRING(100),
-      allowNull: false,
-      unique: true
+      allowNull: false
     },
     phone: {
       type: DataTypes.STRING(20),
@@ -35,8 +34,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     tax_id: {
       type: DataTypes.STRING(20),
-      allowNull: true,
-      unique: true
+      allowNull: true
     },
     is_international: {
       type: DataTypes.BOOLEAN,


### PR DESCRIPTION
Closes #139

## Resumen

- Se eliminó `unique: true` del modelo `customers` en los campos `email` y `tax_id`
- Se creó migración para dropear los constraints `UNIQUE` de la base de datos

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/models/customers.js` | Removido `unique: true` de `email` y `tax_id` |
| `src/database/migrations/20260611000000-remove-unique-email-taxid-customers.js` | Nueva migración que elimina los constraints |

## Motivación

Datos migrados desde el sistema anterior contienen clientes con emails o RFC duplicados. La restricción `UNIQUE` bloqueaba la importación.

## Plan de prueba

- [x] Tests completos pasan (`pnpm test`)
- [x] Migración ejecutada en entorno de test durante el pre-commit hook
- [x] `down()` restaura ambos constraints correctamente