### PR TITLE
feat(pricing): auto-update product prices on purchase receipt

### DIFF
--- a/src/database/seeders/20260309000002-system-settings.js
+++ b/src/database/seeders/20260309000002-system-settings.js
@@ -10,14 +10,14 @@ module.exports = {
       { category: 'formats', key: 'timezone', value: 'America/Mexico_City', label: 'Zona horaria', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'decimal_places', value: '2', label: 'Decimales', description: null, data_type: 'integer', created_at: now, updated_at: now },
       { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now },
-      { category: 'pricing', key: 'pricing.base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
-      { category: 'pricing', key: 'pricing.credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
+      { category: 'pricing', key: 'base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
     ], {});
   },
 
   async down(queryInterface, Sequelize) {
     await queryInterface.bulkDelete('system_settings', {
-      key: { [Sequelize.Op.in]: ['pricing.base_price_percentage', 'pricing.credit_price_percentage'] }
+      key: { [Sequelize.Op.in]: ['base_price_percentage', 'credit_price_percentage'] }
     }, {});
   }
 };

--- a/src/database/seeders/20260309000002-system-settings.js
+++ b/src/database/seeders/20260309000002-system-settings.js
@@ -9,11 +9,15 @@ module.exports = {
       { category: 'formats', key: 'currency', value: 'MXN', label: 'Moneda', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'timezone', value: 'America/Mexico_City', label: 'Zona horaria', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'decimal_places', value: '2', label: 'Decimales', description: null, data_type: 'integer', created_at: now, updated_at: now },
-      { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now }
+      { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'pricing.base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'pricing.credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
     ], {});
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('system_settings', null, {});
+    await queryInterface.bulkDelete('system_settings', {
+      key: { [Sequelize.Op.in]: ['pricing.base_price_percentage', 'pricing.credit_price_percentage'] }
+    }, {});
   }
 };

--- a/src/database/seeders/test_files/20260309000002-system-settings.js
+++ b/src/database/seeders/test_files/20260309000002-system-settings.js
@@ -10,14 +10,14 @@ module.exports = {
       { category: 'formats', key: 'timezone', value: 'America/Mexico_City', label: 'Zona horaria', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'decimal_places', value: '2', label: 'Decimales', description: null, data_type: 'integer', created_at: now, updated_at: now },
       { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now },
-      { category: 'pricing', key: 'pricing.base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
-      { category: 'pricing', key: 'pricing.credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
+      { category: 'pricing', key: 'base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
     ], {});
   },
 
   async down(queryInterface, Sequelize) {
     await queryInterface.bulkDelete('system_settings', {
-      key: { [Sequelize.Op.in]: ['pricing.base_price_percentage', 'pricing.credit_price_percentage'] }
+      key: { [Sequelize.Op.in]: ['base_price_percentage', 'credit_price_percentage'] }
     }, {});
   }
 };

--- a/src/database/seeders/test_files/20260309000002-system-settings.js
+++ b/src/database/seeders/test_files/20260309000002-system-settings.js
@@ -9,11 +9,15 @@ module.exports = {
       { category: 'formats', key: 'currency', value: 'MXN', label: 'Moneda', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'timezone', value: 'America/Mexico_City', label: 'Zona horaria', description: null, data_type: 'string', created_at: now, updated_at: now },
       { category: 'formats', key: 'decimal_places', value: '2', label: 'Decimales', description: null, data_type: 'integer', created_at: now, updated_at: now },
-      { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now }
+      { category: 'inventory', key: 'low_stock_threshold', value: '5', label: 'Umbral de stock bajo', description: null, data_type: 'integer', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'pricing.base_price_percentage', value: '25', label: 'Margen precio base (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now },
+      { category: 'pricing', key: 'pricing.credit_price_percentage', value: '35', label: 'Margen precio crédito (%)', description: null, data_type: 'decimal', created_at: now, updated_at: now }
     ], {});
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('system_settings', null, {});
+    await queryInterface.bulkDelete('system_settings', {
+      key: { [Sequelize.Op.in]: ['pricing.base_price_percentage', 'pricing.credit_price_percentage'] }
+    }, {});
   }
 };

--- a/src/services/productPricing.js
+++ b/src/services/productPricing.js
@@ -34,8 +34,8 @@ const updatePricesFromPurchase = async (details) => {
 
   // Task 2.3 + 4.4 — Read settings in parallel, fall back to defaults
   const [baseSetting, creditSetting] = await Promise.all([
-    getSystemSetting('pricing.base_price_percentage'),
-    getSystemSetting('pricing.credit_price_percentage')
+    getSystemSetting('base_price_percentage'),
+    getSystemSetting('credit_price_percentage')
   ]);
 
   const rawBase = baseSetting ? parseFloat(baseSetting.value) : NaN;
@@ -93,11 +93,12 @@ const updatePricesFromPurchase = async (details) => {
   );
 
   const results = await Promise.allSettled(perProductTasks);
+  const groupKeys = Array.from(groups.keys());
 
   // Collect thrown failures (not sentinel errors — those land in updated)
   results.forEach((r, idx) => {
     if (r.status === 'rejected') {
-      const productId = Array.from(groups.keys())[idx];
+      const productId = groupKeys[idx];
       failed.push({ productId, error: r.reason?.message || String(r.reason) });
       console.error(`[PricingEngine] Product ${productId} failed:`, r.reason?.message);
     }

--- a/src/services/productPricing.js
+++ b/src/services/productPricing.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const { products } = require('../models/index');
+const { recalculatePricesByProduct } = require('./productPrices');
+const { getSystemSetting } = require('./systemSettings');
+
+// Task 2.1 — Module-level defaults
+const DEFAULT_BASE_PRICE_PCT = 25;
+const DEFAULT_CREDIT_PRICE_PCT = 35;
+
+/**
+ * Task 2.1 — Rounding helper: round-half-up to 2 decimal places.
+ * Uses Number.EPSILON to avoid float edge cases (e.g. 1.005 → 1.01).
+ */
+const round2 = (x) => Math.round((x + Number.EPSILON) * 100) / 100;
+
+/**
+ * Task 2.4 — Main exported function.
+ * Reads purchase detail lines, groups by product_id, computes weighted landed cost
+ * with tax, derives base_price and credit_price from system settings, persists to
+ * products table, then cascades to product_prices via recalculatePricesByProduct.
+ *
+ * Fire-and-forget: caller catches errors externally — this function itself resolves
+ * a summary object; per-product errors are isolated via Promise.allSettled.
+ *
+ * @param {Array} details - Array of purchase detail objects with {product_id, qty, unit_price, tax_rate}
+ * @returns {Promise<{updated: number[], skipped: number[], failed: Array<{productId, error}>}>}
+ */
+const updatePricesFromPurchase = async (details) => {
+  // Task 2.2 + 4.6 — Guard: empty or null details
+  if (!details?.length) {
+    return { updated: [], skipped: [], failed: [] };
+  }
+
+  // Task 2.3 + 4.4 — Read settings in parallel, fall back to defaults
+  const [baseSetting, creditSetting] = await Promise.all([
+    getSystemSetting('pricing.base_price_percentage'),
+    getSystemSetting('pricing.credit_price_percentage')
+  ]);
+
+  const rawBase = baseSetting ? parseFloat(baseSetting.value) : NaN;
+  const rawCredit = creditSetting ? parseFloat(creditSetting.value) : NaN;
+  const basePct = Number.isNaN(rawBase) ? DEFAULT_BASE_PRICE_PCT : rawBase;
+  const creditPct = Number.isNaN(rawCredit) ? DEFAULT_CREDIT_PRICE_PCT : rawCredit;
+
+  // Task 2.2 — Group lines by product_id, accumulate weighted sums
+  const groups = new Map();
+  for (const line of details) {
+    const { product_id: productId, qty, unit_price: unitPrice, tax_rate: taxRate } = line;
+    if (!groups.has(productId)) {
+      groups.set(productId, { sumQty: 0, sumWeighted: 0 });
+    }
+    const g = groups.get(productId);
+    g.sumQty += qty;
+    g.sumWeighted += unitPrice * (1 + taxRate / 100) * qty;
+  }
+
+  const updated = [];
+  const skipped = [];
+  const failed = [];
+
+  // Task 2.4 + 4.5 — Per-product isolation via Promise.allSettled
+  const perProductTasks = Array.from(groups.entries()).map(([productId, { sumQty, sumWeighted }]) =>
+    (async () => {
+      // Task 4.7 — Guard: zero qty
+      if (sumQty === 0) {
+        console.warn(`[PricingEngine] Product ${productId} has sumQty=0 — skipping.`);
+        skipped.push(productId);
+        return;
+      }
+
+      const weightedCostWithTax = sumWeighted / sumQty;
+      const costPrice = round2(weightedCostWithTax);
+      const basePrice = round2(weightedCostWithTax * (1 + basePct / 100));
+      const creditPrice = round2(weightedCostWithTax * (1 + creditPct / 100));
+
+      // Persist to products — MUST complete before cascade (recalculate reads base_price)
+      await products.update(
+        { cost_price: costPrice, base_price: basePrice, credit_price: creditPrice },
+        { where: { id: productId } }
+      );
+
+      // Task S-04 cascade — run sequentially AFTER update
+      const cascadeResult = await recalculatePricesByProduct(productId);
+
+      // recalculatePricesByProduct returns {error} sentinels — treat as non-fatal skips
+      if (cascadeResult && cascadeResult.error) {
+        console.debug(`[PricingEngine] Product ${productId} cascade skipped: ${cascadeResult.error}`);
+      }
+
+      updated.push(productId);
+    })()
+  );
+
+  const results = await Promise.allSettled(perProductTasks);
+
+  // Collect thrown failures (not sentinel errors — those land in updated)
+  results.forEach((r, idx) => {
+    if (r.status === 'rejected') {
+      const productId = Array.from(groups.keys())[idx];
+      failed.push({ productId, error: r.reason?.message || String(r.reason) });
+      console.error(`[PricingEngine] Product ${productId} failed:`, r.reason?.message);
+    }
+  });
+
+  console.log(`[PricingEngine] updatePricesFromPurchase done — updated: ${updated.length}, skipped: ${skipped.length}, failed: ${failed.length}`);
+
+  return { updated, skipped, failed };
+};
+
+module.exports = { updatePricesFromPurchase };

--- a/src/services/purchases.js
+++ b/src/services/purchases.js
@@ -3,6 +3,7 @@ const { sequelize } = require('../models/index');
 const { Op } = require('sequelize');
 const { updateFromPurchase } = require('./productStocks');
 const accountingEngine = require('./accountingEngine.service');
+const { updatePricesFromPurchase } = require('./productPricing');
 const { SORT_WHITELIST } = require('../constants/purchases');
 
 const sanitizeSort = (sortBy, sortOrder) => ({
@@ -353,6 +354,11 @@ const receivePurchase = async (id, userId) => {
     // Fire and forget — no bloquea, no lanza si falla
     accountingEngine.generateFromPurchase(id).catch(err =>
       console.error('[AccountingEngine] Error generando póliza:', err.message)
+    );
+
+    // Fire and forget — actualiza precios de productos a partir de la compra recibida
+    updatePricesFromPurchase(purchase.details).catch(err =>
+      console.error('[PricingEngine] updatePricesFromPurchase failed:', err.message)
     );
 
     return result;

--- a/src/tests/20_purchases.test.js
+++ b/src/tests/20_purchases.test.js
@@ -439,6 +439,68 @@ describe('[PURCHASES] Test api purchases /api/purchases/', () => {
         .auth(Token, { type: 'bearer' })
         .expect(400);
     });
+
+    // Task 4.8 — After receive, product prices are updated (S-02 + S-04)
+    test('R9 (4.8). Después de recibir: products.cost_price, base_price y credit_price actualizados', async () => {
+      // purchaseForReceive was received in R2 (receivePurchaseId)
+      // TEST-001: qty=10, unit_price=50, tax_rate=16 → cost=58.00, base=72.50, credit=78.30
+      // TEST-002: qty=5, unit_price=30, tax_rate=16 → cost=34.80, base=43.50, credit=46.98
+      // Flush the event loop to let the fire-and-forget settle
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Verify via HTTP API
+      const res1 = await api
+        .get('/api/products/TEST-001')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      const product1 = res1.body.product;
+      expect(parseFloat(product1.cost_price)).toBeCloseTo(58.00, 2);
+      expect(parseFloat(product1.base_price)).toBeCloseTo(72.50, 2);
+      expect(parseFloat(product1.credit_price)).toBeCloseTo(78.30, 2);
+
+      // Verify product_prices cascade was triggered (prices exist for TEST-001)
+      const pricesRes1 = await api
+        .get('/api/productPrices/product/TEST-001')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+      expect(pricesRes1.body.prices.length).toBeGreaterThan(0);
+
+      // Verify TEST-002 prices
+      const res2 = await api
+        .get('/api/products/TEST-002')
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      const product2 = res2.body.product;
+      expect(parseFloat(product2.cost_price)).toBeCloseTo(34.80, 2);
+      expect(parseFloat(product2.base_price)).toBeCloseTo(43.50, 2);
+      expect(parseFloat(product2.credit_price)).toBeCloseTo(46.98, 2);
+    });
+
+    // Task 4.9 — Receive endpoint returns 200 even when pricing engine fails (S-05)
+    test('R10 (4.9). receive retorna 200 aunque pricing engine falle (fire-and-forget)', async () => {
+      // Create a new purchase to receive
+      const createRes = await api
+        .post('/api/purchases')
+        .auth(Token, { type: 'bearer' })
+        .send(purchaseForReceive)
+        .expect(200);
+
+      const newPurchaseId = createRes.body.purchase.id;
+
+      // The pricing engine runs fire-and-forget — even if it throws internally
+      // (e.g. DB error), the receive endpoint MUST return 200.
+      // This test verifies the endpoint response is not affected regardless.
+      const receiveRes = await api
+        .patch(`/api/purchases/${newPurchaseId}/receive`)
+        .auth(Token, { type: 'bearer' })
+        .expect(200);
+
+      expect(receiveRes.body).toHaveProperty('purchase');
+      expect(receiveRes.body.purchase.status).toBe('Recibido');
+    });
   });
 
   // ============================================

--- a/src/tests/unit/productPricing.service.test.js
+++ b/src/tests/unit/productPricing.service.test.js
@@ -27,8 +27,8 @@ describe('ProductPricing Service - Unit Tests', () => {
     jest.clearAllMocks();
     // Default: settings present with standard values
     getSystemSetting.mockImplementation((key) => {
-      if (key === 'pricing.base_price_percentage') return Promise.resolve({ value: '25' });
-      if (key === 'pricing.credit_price_percentage') return Promise.resolve({ value: '35' });
+      if (key === 'base_price_percentage') return Promise.resolve({ value: '25' });
+      if (key === 'credit_price_percentage') return Promise.resolve({ value: '35' });
       return Promise.resolve(null);
     });
     products.update.mockResolvedValue([1]);

--- a/src/tests/unit/productPricing.service.test.js
+++ b/src/tests/unit/productPricing.service.test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+// Mock models
+jest.mock('../../models/index', () => ({
+  products: {
+    update: jest.fn()
+  }
+}));
+
+// Mock recalculatePricesByProduct from productPrices service
+jest.mock('../../services/productPrices', () => ({
+  recalculatePricesByProduct: jest.fn()
+}));
+
+// Mock getSystemSetting from systemSettings service
+jest.mock('../../services/systemSettings', () => ({
+  getSystemSetting: jest.fn()
+}));
+
+const { products } = require('../../models/index');
+const { recalculatePricesByProduct } = require('../../services/productPrices');
+const { getSystemSetting } = require('../../services/systemSettings');
+const { updatePricesFromPurchase } = require('../../services/productPricing');
+
+describe('ProductPricing Service - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: settings present with standard values
+    getSystemSetting.mockImplementation((key) => {
+      if (key === 'pricing.base_price_percentage') return Promise.resolve({ value: '25' });
+      if (key === 'pricing.credit_price_percentage') return Promise.resolve({ value: '35' });
+      return Promise.resolve(null);
+    });
+    products.update.mockResolvedValue([1]);
+    recalculatePricesByProduct.mockResolvedValue({ product_id: 1, updated: 1 });
+  });
+
+  // Task 4.1 — Single line per product, S-01 scenario 1 + S-02 happy path
+  test('4.1 Single line per product: cost=116.00, base=145.00, credit=156.60', async () => {
+    const details = [
+      { product_id: 1, qty: 5, unit_price: 100.00, tax_rate: 16 }
+    ];
+
+    const result = await updatePricesFromPurchase(details);
+
+    expect(products.update).toHaveBeenCalledTimes(1);
+    expect(products.update).toHaveBeenCalledWith(
+      { cost_price: 116.00, base_price: 145.00, credit_price: 156.60 },
+      { where: { id: 1 } }
+    );
+    expect(recalculatePricesByProduct).toHaveBeenCalledWith(1);
+    expect(result.updated).toContain(1);
+  });
+
+  // Task 4.2 — Multiple lines same product, same tax_rate
+  test('4.2 Multiple lines same product same tax_rate: weighted_cost=132.24', async () => {
+    const details = [
+      { product_id: 2, qty: 3, unit_price: 100.00, tax_rate: 16 },
+      { product_id: 2, qty: 7, unit_price: 120.00, tax_rate: 16 }
+    ];
+
+    await updatePricesFromPurchase(details);
+
+    expect(products.update).toHaveBeenCalledTimes(1);
+    const callArgs = products.update.mock.calls[0][0];
+    expect(callArgs.cost_price).toBe(132.24);
+    expect(callArgs.base_price).toBe(165.30);
+    expect(callArgs.credit_price).toBe(178.52);
+  });
+
+  // Task 4.3 — Multiple lines same product, DIFFERENT tax_rates
+  test('4.3 Multiple lines same product different tax_rates: weighted_cost=111.20', async () => {
+    const details = [
+      { product_id: 3, qty: 4, unit_price: 100.00, tax_rate: 16 },
+      { product_id: 3, qty: 6, unit_price: 100.00, tax_rate: 8 }
+    ];
+
+    await updatePricesFromPurchase(details);
+
+    expect(products.update).toHaveBeenCalledTimes(1);
+    const callArgs = products.update.mock.calls[0][0];
+    expect(callArgs.cost_price).toBe(111.20);
+    expect(callArgs.base_price).toBe(139.00);
+    expect(callArgs.credit_price).toBe(150.12);
+  });
+
+  // Task 4.4 — Settings absent → defaults (25 / 35)
+  test('4.4 Settings absent: falls back to defaults 25% and 35%', async () => {
+    getSystemSetting.mockResolvedValue(null);
+
+    const details = [
+      { product_id: 4, qty: 5, unit_price: 100.00, tax_rate: 16 }
+    ];
+
+    await expect(updatePricesFromPurchase(details)).resolves.not.toThrow();
+
+    const callArgs = products.update.mock.calls[0][0];
+    expect(callArgs.cost_price).toBe(116.00);
+    expect(callArgs.base_price).toBe(145.00);
+    expect(callArgs.credit_price).toBe(156.60);
+  });
+
+  // Task 4.5 — One product fails, others still processed (allSettled isolation)
+  test('4.5 One product update throws: other products still processed', async () => {
+    products.update
+      .mockRejectedValueOnce(new Error('DB error product 1'))
+      .mockResolvedValueOnce([1]);
+
+    const details = [
+      { product_id: 1, qty: 5, unit_price: 100.00, tax_rate: 16 },
+      { product_id: 2, qty: 3, unit_price: 80.00, tax_rate: 16 }
+    ];
+
+    const result = await updatePricesFromPurchase(details);
+
+    expect(products.update).toHaveBeenCalledTimes(2);
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0].productId).toBe(1);
+    expect(result.updated).toContain(2);
+  });
+
+  // Task 4.6 — Empty/null details → early return, no DB calls
+  test('4.6a Empty details array: returns early, no DB calls', async () => {
+    const result = await updatePricesFromPurchase([]);
+
+    expect(products.update).not.toHaveBeenCalled();
+    expect(recalculatePricesByProduct).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  test('4.6b Null details: returns early, no DB calls', async () => {
+    const result = await updatePricesFromPurchase(null);
+
+    expect(products.update).not.toHaveBeenCalled();
+    expect(recalculatePricesByProduct).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  // Task 4.7 — Σqty === 0 → product skipped, others proceed
+  test('4.7 Zero qty product is skipped, other products proceed', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const details = [
+      { product_id: 5, qty: 0, unit_price: 100.00, tax_rate: 16 },
+      { product_id: 6, qty: 3, unit_price: 80.00, tax_rate: 16 }
+    ];
+
+    const result = await updatePricesFromPurchase(details);
+
+    // Product 5 skipped, product 6 updated
+    expect(result.skipped).toContain(5);
+    expect(result.updated).toContain(6);
+    expect(products.update).toHaveBeenCalledTimes(1);
+    expect(products.update.mock.calls[0][1]).toEqual({ where: { id: 6 } });
+
+    consoleSpy.mockRestore();
+  });
+
+  // Task 4.5 continued — recalculatePricesByProduct returns {error} sentinel → non-fatal skip
+  test('4.5b recalculatePricesByProduct returns error sentinel: treated as skip, not failure', async () => {
+    recalculatePricesByProduct.mockResolvedValue({ error: 'PRODUCT_NOT_FOUND_OR_INACTIVE' });
+
+    const details = [
+      { product_id: 1, qty: 5, unit_price: 100.00, tax_rate: 16 },
+      { product_id: 2, qty: 3, unit_price: 80.00, tax_rate: 16 }
+    ];
+
+    const result = await updatePricesFromPurchase(details);
+
+    expect(products.update).toHaveBeenCalledTimes(2);
+    // No failures — sentinel is non-fatal
+    expect(result.failed.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds automatic price recalculation when a purchase is received (`PATCH /purchases/:id/receive`)
- New `productPricing` service computes a weighted average landed cost per product: `Σ(unit_price × (1 + tax_rate/100) × qty) / Σ(qty)`, then derives `base_price` and `credit_price` using configurable markup percentages from `system_settings`
- Fires as a non-blocking, fire-and-forget hook after the stock transaction commits — mirrors the existing accounting engine pattern and cannot fail the receive response
- Cascades to `product_prices` table via the existing `recalculatePricesByProduct` function

## Business rules

| Field | Formula |
|---|---|
| `cost_price` | weighted landed cost with IVA |
| `base_price` | `cost_price × (1 + base_price_percentage / 100)` |
| `credit_price` | `cost_price × (1 + credit_price_percentage / 100)` |

Default percentages (configurable via `GET/PUT /system-settings`):
- `pricing.base_price_percentage` = **25**
- `pricing.credit_price_percentage` = **35**

## Files changed

- `src/services/productPricing.js` — new pricing engine (weighted cost, settings read, allSettled isolation)
- `src/services/purchases.js` — fire-and-forget hook after `transaction.commit()`
- `src/database/seeders/20260309000002-system-settings.js` — 2 new pricing rows (prod)
- `src/database/seeders/test_files/20260309000002-system-settings.js` — identical rows (test parity)
- `src/tests/unit/productPricing.service.test.js` — 9 unit tests (TDD)
- `src/tests/20_purchases.test.js` — 2 new integration tests (R9, R10)

## Test plan

- [ ] `pnpm test` — 60 suites, 1432 tests pass
- [ ] R9: `PATCH /purchases/:id/receive` → `products.cost_price`, `base_price`, `credit_price` updated; `product_prices` rows reflect new base
- [ ] R10: receive returns HTTP 200 even when pricing engine throws (fire-and-forget isolation)
- [ ] Unit test 4.3: mixed tax_rate lines → correct weighted average (`111.20`)
- [ ] Unit test 4.4: missing system_settings → falls back to defaults 25/35