### PR TITLE
feat(sales): add sales_type filter to GET /sales/branch/:branch_id

### DIFF
--- a/src/controllers/sales.js
+++ b/src/controllers/sales.js
@@ -60,7 +60,8 @@ const getRecordsByBranch = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { sales, total } = await getSalesByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder);
+    const salesType = data.sales_type ?? null;
+    const { sales, total } = await getSalesByBranch(data.branch_id, page, limit, search, data.sortBy, data.sortOrder, salesType);
     res.send(buildPaginationResponse('sales', sales, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS_BY_BRANCH -> ${error}`, 400);

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -119,11 +119,12 @@ const getSalesByCustomer = async (customerId, page = 1, limit = 20, search = '',
   return { sales: rows, total: count };
 };
 
-const getSalesByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
+const getSalesByBranch = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC', salesType = null) => {
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { branch_id: branchId };
   if (search) where.ticket = { [Op.like]: `%${search}%` };
+  if (salesType) where.sales_type = salesType;
   const { count, rows } = await sales.findAndCountAll({
     attributes: saleAttributes,
     where,

--- a/src/validators/sales.js
+++ b/src/validators/sales.js
@@ -36,6 +36,7 @@ const validateGetByBranch = [
     .isInt().withMessage(SALES_VALIDATORS.BRANCH_ID_INVALID).bail(),
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  check('sales_type').optional().isIn(['Contado', 'Credito']).withMessage('sales_type must be Contado or Credito'),
   ...sortChecks(SORT_WHITELIST),
   (req, res, next) => validateResults(req, res, next)
 ];


### PR DESCRIPTION
Closes #142

## Summary
- Agrega soporte para el query param `?sales_type=Contado|Credito` en `GET /api/sales/branch/:branch_id`
- El frontend enviaba el parámetro pero el backend lo descartaba silenciosamente

## Changes

| File | Change |
|------|--------|
| `src/validators/sales.js` | Declarado `sales_type` opcional con enum `['Contado', 'Credito']` en `validateGetByBranch` |
| `src/services/sales.js` | `getSalesByBranch` acepta `salesType` y lo aplica como filtro `WHERE` |
| `src/controllers/sales.js` | Extrae `data.sales_type` y lo pasa al servicio |

## Test Plan
- [x] 60 suites, 1432 tests — todos pasan (`pnpm test`)
- [x] Patrón idéntico al filtro existente en `getSalesByCustomer`