### PR TITLE
feat(dashboard): add sort_by param to GET /dashboard/top-products

### DIFF
--- a/src/controllers/dashboard.js
+++ b/src/controllers/dashboard.js
@@ -24,8 +24,8 @@ const getTrends = async (req, res) => {
 
 const getTopProductsHandler = async (req, res) => {
   try {
-    const { limit = 10, months = 3 } = matchedData(req);
-    const products = await getTopProducts(limit, months);
+    const { limit = 10, months = 3, sort_by: sortBy = 'unidades_vendidas' } = matchedData(req);
+    const products = await getTopProducts(limit, months, sortBy);
     res.send({ products });
   } catch (error) {
     handleHttpError(res, `ERROR_GET_TOP_PRODUCTS -> ${error}`);

--- a/src/routes/dashboard.js
+++ b/src/routes/dashboard.js
@@ -105,10 +105,11 @@ router.get('/trends',
  *   get:
  *     tags:
  *       - dashboard
- *     summary: Top productos por ingreso
+ *     summary: Top productos por unidades vendidas o ingreso
  *     description: |
- *       Retorna los N productos con mayor ingreso total en los últimos M meses,
- *       calculado sobre ventas no canceladas. Ordenado por ingreso_total DESC.
+ *       Retorna los N productos con mayor ranking en los últimos M meses,
+ *       calculado sobre ventas no canceladas. El criterio de ordenamiento
+ *       se controla con `sort_by` (default: `unidades_vendidas`).
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -130,9 +131,17 @@ router.get('/trends',
  *           maximum: 24
  *           default: 3
  *         description: Cantidad de meses hacia atrás a considerar
+ *       - name: sort_by
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: string
+ *           enum: [unidades_vendidas, ingreso_total]
+ *           default: unidades_vendidas
+ *         description: Campo por el cual ordenar el ranking de productos (DESC)
  *     responses:
  *       '200':
- *         description: Arreglo de productos ordenado por ingreso DESC
+ *         description: Arreglo de productos ordenado por el criterio indicado (DESC)
  *         content:
  *           application/json:
  *             schema:

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -44,7 +44,13 @@ const getDashboardTrends = async (months = 6) => {
   return results;
 };
 
-const getTopProducts = async (limit = 10, months = 3) => {
+const TOP_PRODUCTS_SORT_COLUMNS = {
+  unidades_vendidas: 'unidades_vendidas',
+  ingreso_total: 'ingreso_total'
+};
+
+const getTopProducts = async (limit = 10, months = 3, sortBy = 'unidades_vendidas') => {
+  const orderColumn = TOP_PRODUCTS_SORT_COLUMNS[sortBy] || 'unidades_vendidas';
   const [results] = await sequelize.query(`
     SELECT
       sd.product_id,
@@ -58,7 +64,7 @@ const getTopProducts = async (limit = 10, months = 3) => {
       AND s.sales_date >= DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL :months MONTH), '%Y-%m-01')
     INNER JOIN products p ON p.id = sd.product_id AND p.deleted_at IS NULL
     GROUP BY sd.product_id, p.name
-    ORDER BY ingreso_total DESC
+    ORDER BY ${orderColumn} DESC
     LIMIT :limit
   `, { replacements: { limit, months } });
   return results;

--- a/src/tests/unit/dashboard.service.test.js
+++ b/src/tests/unit/dashboard.service.test.js
@@ -141,10 +141,21 @@ describe('Dashboard Service - Unit Tests', () => {
       );
     });
 
-    test('debe ordenar por ingreso total descendente', async() => {
+    test('debe ordenar por unidades_vendidas por defecto', async() => {
       sequelize.query.mockResolvedValue([[]]);
 
       await getTopProducts(5);
+
+      expect(sequelize.query).toHaveBeenCalledWith(
+        expect.stringContaining('ORDER BY unidades_vendidas DESC'),
+        expect.any(Object)
+      );
+    });
+
+    test('debe ordenar por ingreso_total cuando se indica', async() => {
+      sequelize.query.mockResolvedValue([[]]);
+
+      await getTopProducts(5, 3, 'ingreso_total');
 
       expect(sequelize.query).toHaveBeenCalledWith(
         expect.stringContaining('ORDER BY ingreso_total DESC'),

--- a/src/validators/dashboard.js
+++ b/src/validators/dashboard.js
@@ -14,6 +14,7 @@ const validateTrends = [
 const validateTopProducts = [
   query('limit').optional().isInt({ min: 1, max: 50 }).toInt(),
   query('months').optional().isInt({ min: 1, max: 24 }).toInt(),
+  query('sort_by').optional().isIn(['ingreso_total', 'unidades_vendidas']),
   (req, res, next) => validateResults(req, res, next)
 ];
 


### PR DESCRIPTION
## Summary
- Agrega query param opcional `sort_by` al endpoint `GET /dashboard/top-products`
- Valores válidos: `unidades_vendidas` (default) | `ingreso_total`
- Protegido contra SQL injection via whitelist en el service (no interpolación directa del input)

## Changes

| File | Change |
|------|--------|
| `src/services/dashboard.js` | Whitelist `TOP_PRODUCTS_SORT_COLUMNS` + parámetro `sortBy` en `getTopProducts` |
| `src/controllers/dashboard.js` | Desestructura `sort_by` → `sortBy` desde `matchedData`; default `unidades_vendidas` |
| `src/validators/dashboard.js` | Valida `sort_by` con `isIn(['ingreso_total', 'unidades_vendidas'])` |
| `src/routes/dashboard.js` | Documenta el parámetro `sort_by` en `@openapi` |
| `src/tests/unit/dashboard.service.test.js` | Actualiza test de orden y agrega caso para `ingreso_total` |

## Test Plan
- [x] Suite completa: 60 suites, 1433 tests — todos passing
- [x] Lint sin errores (camelCase alias en desestructurado del controller)
- [x] SQL injection descartado: el valor de `sort_by` nunca toca la query cruda