### PR TITLE
perf(productStocks): fix incompatible subquery syntax and remove unnecessary distinct

### DIFF
--- a/src/services/productStocks.js
+++ b/src/services/productStocks.js
@@ -58,8 +58,7 @@ const getAllProductStocks = async (branchId = null, page = 1, limit = 20, search
       }
     ],
     limit,
-    offset,
-    distinct: true
+    offset
   });
   return { stocks: rows, total: count };
 };
@@ -100,8 +99,7 @@ const getStocksByProduct = async (productId, page = 1, limit = 20, search = '') 
       }
     ],
     limit,
-    offset,
-    distinct: true
+    offset
   });
   return { stocks: rows, total: count };
 };
@@ -110,31 +108,32 @@ const getStocksByBranch = async (branchId, page = 1, limit = 20, search = '', so
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
 
-  const productInclude = {
-    model: products,
-    as: 'product',
-    attributes: productAttributes,
-    required: !!search
-  };
-
   const where = { branch_id: branchId };
   if (inStock) where.quantity = { [Op.gt]: 0 };
   if (search) {
+    const matchingProducts = await products.findAll({
+      where: {
+        [Op.or]: [
+          { id: { [Op.like]: `%${search}%` } },
+          { name: { [Op.like]: `%${search}%` } }
+        ]
+      },
+      attributes: ['id']
+    });
+    const productIds = matchingProducts.map(p => p.id);
     where[Op.or] = [
       { bar_code: search },
-      { '$product.id$': { [Op.like]: `%${search}%` } },
-      { '$product.name$': { [Op.like]: `%${search}%` } }
+      ...(productIds.length ? [{ product_id: { [Op.in]: productIds } }] : [])
     ];
   }
 
   const { count, rows } = await productStocks.findAndCountAll({
     attributes,
     where,
-    include: [productInclude],
+    include: [{ model: products, as: 'product', attributes: productAttributes }],
     order: buildSortOrder(safeSortBy, safeSortOrder),
     limit,
-    offset,
-    distinct: true
+    offset
   });
   return { stocks: rows, total: count };
 };


### PR DESCRIPTION
Closes #145

## Problema

`getStocksByBranch` usaba la sintaxis `$product.id$` y `$product.name$` en el `where` principal para filtrar por campos de una tabla joineada. Esta sintaxis es **incompatible con `subQuery: true`**, que Sequelize activa automáticamente cuando se combina `findAndCountAll` con `limit/offset`. Resultado: la búsqueda rompía la paginación silenciosamente.

Adicionalmente, `getAllProductStocks` y `getStocksByProduct` tenían `distinct: true` innecesario — ambas solo incluyen relaciones `belongsTo` que no generan multiplicación de filas.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/services/productStocks.js` | `getStocksByBranch`: pre-fetch de product IDs reemplaza `$product.field$`; `required: !!search` removido; `distinct: true` removido de las 3 funciones paginadas |

## Detalle del fix en `getStocksByBranch`

```js
// ❌ Antes — incompatible con subQuery
where[Op.or] = [
  { bar_code: search },
  { '$product.id$': { [Op.like]: `%${search}%` } },
  { '$product.name$': { [Op.like]: `%${search}%` } }
];

// ✅ Después — pre-fetch de IDs, filtro en tabla principal
const matchingProducts = await products.findAll({
  where: { [Op.or]: [{ id: { [Op.like]: `%${search}%` } }, { name: { [Op.like]: `%${search}%` } }] },
  attributes: ['id']
});
where[Op.or] = [
  { bar_code: search },
  ...(matchingProducts.length ? [{ product_id: { [Op.in]: matchingProducts.map(p => p.id) } }] : [])
];
```

## Test plan

- [x] `pnpm test` — 60 suites, 1433 tests, 0 fallos