### PR TITLE
perf(db): Stage 1 — compound indexes on sales, sale_installments, stock_movements

### DIFF
--- a/src/database/migrations/20260701000001-add-idx-sales-branch-date.js
+++ b/src/database/migrations/20260701000001-add-idx-sales-branch-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['branch_id', 'sales_date'], {
+      name: 'idx_sales_branch_id_sales_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_branch_id_sales_date');
+  }
+};

--- a/src/database/migrations/20260701000002-add-idx-sales-branch-type-status.js
+++ b/src/database/migrations/20260701000002-add-idx-sales-branch-type-status.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['branch_id', 'sales_type', 'status'], {
+      name: 'idx_sales_branch_id_sales_type_status',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_branch_id_sales_type_status');
+  }
+};

--- a/src/database/migrations/20260701000003-add-idx-sales-type.js
+++ b/src/database/migrations/20260701000003-add-idx-sales-type.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['sales_type'], {
+      name: 'idx_sales_sales_type',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_sales_type');
+  }
+};

--- a/src/database/migrations/20260701000004-add-idx-sale-installments-status-due.js
+++ b/src/database/migrations/20260701000004-add-idx-sale-installments-status-due.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sale_installments', ['status', 'due_date'], {
+      name: 'idx_sale_installments_status_due_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sale_installments', 'idx_sale_installments_status_due_date');
+  }
+};

--- a/src/database/migrations/20260701000005-add-idx-stock-movements-prod-branch-ref-created.js
+++ b/src/database/migrations/20260701000005-add-idx-stock-movements-prod-branch-ref-created.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE `stock_movements` ADD INDEX `idx_stock_mov_prod_branch_ref_created` (`product_id`, `branch_id`, `reference_type`, `created_at`), ALGORITHM=INPLACE, LOCK=NONE'
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE `stock_movements` DROP INDEX `idx_stock_mov_prod_branch_ref_created`'
+    );
+  }
+};


### PR DESCRIPTION
Closes #95

## PR Type
- [x] New feature / performance improvement

## Summary
- Agrega 5 índices compound/single-column identificados en auditoría exhaustiva de las 8 tablas de mayor impacto
- Stage 1 cubre las dos tablas críticas (score 5/5): `sales` y `stock_movements`
- Zero cambios de código de negocio — solo migrations

## Changes

| File | Change |
|------|--------|
| `src/database/migrations/20260701000001-add-idx-sales-branch-date.js` | ADD INDEX `(branch_id, sales_date)` en sales — cubre getDailyMovement y dashboard trends |
| `src/database/migrations/20260701000002-add-idx-sales-branch-type-status.js` | ADD INDEX `(branch_id, sales_type, status)` en sales — cubre getAccountsReceivable y filtros combinados |
| `src/database/migrations/20260701000003-add-idx-sales-type.js` | ADD INDEX `(sales_type)` en sales — cubre ORDER BY / GROUP BY sin full scan |
| `src/database/migrations/20260701000004-add-idx-sale-installments-status-due.js` | ADD INDEX `(status, due_date)` en sale_installments — cubre getOverdueSales y dashboard KPIs |
| `src/database/migrations/20260701000005-add-idx-stock-movements-prod-branch-ref-created.js` | ADD INDEX `(product_id, branch_id, reference_type, created_at)` en stock_movements via raw DDL con ALGORITHM=INPLACE, LOCK=NONE — resuelve los 7 correlated subqueries del getInventoryReport |

## Test Plan
- [x] `pnpm test` — 60 suites, 1433 tests, 0 failures
- [x] Migrations validadas en DB local con EXPLAIN (cost 0.87 vs 17,000+ sin índice)
- [x] `down()` verificado en cada migration — rollback limpio
- [x] Diff contiene únicamente archivos de migration

## Notes
- T1.5 usa `queryInterface.sequelize.query()` raw porque Sequelize `addIndex` no emite `ALGORITHM=INPLACE, LOCK=NONE`; la sintaxis `ADD INDEX ..., ALGORITHM=INPLACE` (con coma) es requerida por MySQL 9.x
- Stages 2 y 3 pendientes en PRs separados (auto-chain → stacked-to-main)