### PR TITLE
perf(db): Stage 2 — compound indexes on purchases, transfers, expenses, product_stocks

### DIFF
--- a/src/database/migrations/20260702000001-add-idx-product-stocks-purch.js
+++ b/src/database/migrations/20260702000001-add-idx-product-stocks-purch.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('product_stocks', ['purch_id'], {
+      name: 'idx_product_stocks_purch_id',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('product_stocks', 'idx_product_stocks_purch_id');
+  }
+};

--- a/src/database/migrations/20260702000002-add-idx-purchases-branch-date.js
+++ b/src/database/migrations/20260702000002-add-idx-purchases-branch-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('purchases', ['branch_id', 'purch_date'], {
+      name: 'idx_purchases_branch_id_purch_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('purchases', 'idx_purchases_branch_id_purch_date');
+  }
+};

--- a/src/database/migrations/20260702000003-add-idx-purchases-supplier-date.js
+++ b/src/database/migrations/20260702000003-add-idx-purchases-supplier-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('purchases', ['supplier_id', 'purch_date'], {
+      name: 'idx_purchases_supplier_id_purch_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('purchases', 'idx_purchases_supplier_id_purch_date');
+  }
+};

--- a/src/database/migrations/20260702000004-add-idx-transfers-from-date.js
+++ b/src/database/migrations/20260702000004-add-idx-transfers-from-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('transfers', ['from_branch_id', 'transfer_date'], {
+      name: 'idx_transfers_from_branch_id_transfer_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('transfers', 'idx_transfers_from_branch_id_transfer_date');
+  }
+};

--- a/src/database/migrations/20260702000005-add-idx-transfers-to-date.js
+++ b/src/database/migrations/20260702000005-add-idx-transfers-to-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('transfers', ['to_branch_id', 'transfer_date'], {
+      name: 'idx_transfers_to_branch_id_transfer_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('transfers', 'idx_transfers_to_branch_id_transfer_date');
+  }
+};

--- a/src/database/migrations/20260702000006-add-idx-expenses-branch-trans.js
+++ b/src/database/migrations/20260702000006-add-idx-expenses-branch-trans.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('expenses', ['branch_id', 'trans_date'], {
+      name: 'idx_expenses_branch_id_trans_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('expenses', 'idx_expenses_branch_id_trans_date');
+  }
+};


### PR DESCRIPTION
Closes #95

## PR Type
- [x] New feature / performance improvement

## Summary
- Agrega 6 índices compound/single-column en los 4 módulos de impacto medio (score 2-3/5)
- Cubre FK sin índice (`product_stocks.purch_id`) y todos los compound branch+date faltantes
- Zero cambios de código de negocio — solo migrations
- Parte 2 de 3 en la cadena de PRs del db-index-audit (stacked-to-main)

## Changes

| File | Change |
|------|--------|
| `src/database/migrations/20260702000001-add-idx-product-stocks-purch.js` | ADD INDEX `purch_id` en product_stocks — FK sin índice desde ALTER migration original |
| `src/database/migrations/20260702000002-add-idx-purchases-branch-date.js` | ADD INDEX `(branch_id, purch_date)` en purchases — cubre getAllPurchases + ORDER BY |
| `src/database/migrations/20260702000003-add-idx-purchases-supplier-date.js` | ADD INDEX `(supplier_id, purch_date)` en purchases — cubre getPurchasesBySupplier |
| `src/database/migrations/20260702000004-add-idx-transfers-from-date.js` | ADD INDEX `(from_branch_id, transfer_date)` en transfers |
| `src/database/migrations/20260702000005-add-idx-transfers-to-date.js` | ADD INDEX `(to_branch_id, transfer_date)` en transfers |
| `src/database/migrations/20260702000006-add-idx-expenses-branch-trans.js` | ADD INDEX `(branch_id, trans_date)` en expenses — cubre dashboard aggregations |

## Test Plan
- [x] `pnpm test` — 60 suites, 1433 tests, 0 failures
- [x] EXPLAIN validado en DB local — Covering index lookup (reverse) en purchases, transfers y expenses sin filesort
- [x] `down()` correcto en cada migration — rollback limpio con `removeIndex` por nombre
- [x] Diff contiene únicamente archivos de migration

## Notes
- Merge después de PR #148 (Stage 1) — dependencia de orden en la cadena stacked-to-main
- Stage 3 (FULLTEXT + cleanup) pendiente en PR separado