### PR TITLE
perf(db): stage 3 — fulltext indexes, campaigns compound index, drop redundant product_stocks indexes

### DIFF
--- a/src/database/migrations/20260701000001-add-idx-sales-branch-date.js
+++ b/src/database/migrations/20260701000001-add-idx-sales-branch-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['branch_id', 'sales_date'], {
+      name: 'idx_sales_branch_id_sales_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_branch_id_sales_date');
+  }
+};

--- a/src/database/migrations/20260701000002-add-idx-sales-branch-type-status.js
+++ b/src/database/migrations/20260701000002-add-idx-sales-branch-type-status.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['branch_id', 'sales_type', 'status'], {
+      name: 'idx_sales_branch_id_sales_type_status',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_branch_id_sales_type_status');
+  }
+};

--- a/src/database/migrations/20260701000003-add-idx-sales-type.js
+++ b/src/database/migrations/20260701000003-add-idx-sales-type.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sales', ['sales_type'], {
+      name: 'idx_sales_sales_type',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sales', 'idx_sales_sales_type');
+  }
+};

--- a/src/database/migrations/20260701000004-add-idx-sale-installments-status-due.js
+++ b/src/database/migrations/20260701000004-add-idx-sale-installments-status-due.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('sale_installments', ['status', 'due_date'], {
+      name: 'idx_sale_installments_status_due_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('sale_installments', 'idx_sale_installments_status_due_date');
+  }
+};

--- a/src/database/migrations/20260701000005-add-idx-stock-movements-prod-branch-ref-created.js
+++ b/src/database/migrations/20260701000005-add-idx-stock-movements-prod-branch-ref-created.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE `stock_movements` ADD INDEX `idx_stock_mov_prod_branch_ref_created` (`product_id`, `branch_id`, `reference_type`, `created_at`), ALGORITHM=INPLACE, LOCK=NONE'
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE `stock_movements` DROP INDEX `idx_stock_mov_prod_branch_ref_created`'
+    );
+  }
+};

--- a/src/database/migrations/20260702000001-add-idx-product-stocks-purch.js
+++ b/src/database/migrations/20260702000001-add-idx-product-stocks-purch.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('product_stocks', ['purch_id'], {
+      name: 'idx_product_stocks_purch_id',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('product_stocks', 'idx_product_stocks_purch_id');
+  }
+};

--- a/src/database/migrations/20260702000002-add-idx-purchases-branch-date.js
+++ b/src/database/migrations/20260702000002-add-idx-purchases-branch-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('purchases', ['branch_id', 'purch_date'], {
+      name: 'idx_purchases_branch_id_purch_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('purchases', 'idx_purchases_branch_id_purch_date');
+  }
+};

--- a/src/database/migrations/20260702000003-add-idx-purchases-supplier-date.js
+++ b/src/database/migrations/20260702000003-add-idx-purchases-supplier-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('purchases', ['supplier_id', 'purch_date'], {
+      name: 'idx_purchases_supplier_id_purch_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('purchases', 'idx_purchases_supplier_id_purch_date');
+  }
+};

--- a/src/database/migrations/20260702000004-add-idx-transfers-from-date.js
+++ b/src/database/migrations/20260702000004-add-idx-transfers-from-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('transfers', ['from_branch_id', 'transfer_date'], {
+      name: 'idx_transfers_from_branch_id_transfer_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('transfers', 'idx_transfers_from_branch_id_transfer_date');
+  }
+};

--- a/src/database/migrations/20260702000005-add-idx-transfers-to-date.js
+++ b/src/database/migrations/20260702000005-add-idx-transfers-to-date.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('transfers', ['to_branch_id', 'transfer_date'], {
+      name: 'idx_transfers_to_branch_id_transfer_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('transfers', 'idx_transfers_to_branch_id_transfer_date');
+  }
+};

--- a/src/database/migrations/20260702000006-add-idx-expenses-branch-trans.js
+++ b/src/database/migrations/20260702000006-add-idx-expenses-branch-trans.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('expenses', ['branch_id', 'trans_date'], {
+      name: 'idx_expenses_branch_id_trans_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('expenses', 'idx_expenses_branch_id_trans_date');
+  }
+};

--- a/src/database/migrations/20260703000001-add-idx-campaigns-active-dates.js
+++ b/src/database/migrations/20260703000001-add-idx-campaigns-active-dates.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('campaigns', ['is_active', 'start_date', 'end_date'], {
+      name: 'idx_campaigns_is_active_start_date_end_date',
+      using: 'BTREE'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('campaigns', 'idx_campaigns_is_active_start_date_end_date');
+  }
+};

--- a/src/database/migrations/20260703000002-add-fulltext-products-name.js
+++ b/src/database/migrations/20260703000002-add-fulltext-products-name.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('products', ['name'], {
+      name: 'ft_products_name',
+      type: 'FULLTEXT'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('products', 'ft_products_name');
+  }
+};

--- a/src/database/migrations/20260703000003-add-fulltext-customers-name.js
+++ b/src/database/migrations/20260703000003-add-fulltext-customers-name.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addIndex('customers', ['name'], {
+      name: 'ft_customers_name',
+      type: 'FULLTEXT'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('customers', 'ft_customers_name');
+  }
+};

--- a/src/database/migrations/20260703000004-remove-redundant-product-stocks-idx.js
+++ b/src/database/migrations/20260703000004-remove-redundant-product-stocks-idx.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Remove redundant single-column indexes on product_stocks that are covered by
+ * the compound index product_stocks_product_branch_idx (product_id, branch_id).
+ *
+ * NOTE: product_stocks_branch_id is intentionally NOT dropped here because MySQL
+ * requires it to satisfy the foreign key constraint on branch_id (the compound
+ * index product_stocks_product_branch_idx starts with product_id, not branch_id,
+ * so it does not satisfy the FK left-prefix requirement for branch_id).
+ */
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // product_stocks_product_id: covered by compound idx (product_id, branch_id)
+    await queryInterface.removeIndex('product_stocks', 'product_stocks_product_id');
+    // product_stocks_quantity: high write overhead, minimal query benefit
+    await queryInterface.removeIndex('product_stocks', 'product_stocks_quantity');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addIndex('product_stocks', ['product_id'], {
+      name: 'product_stocks_product_id',
+      using: 'BTREE'
+    });
+    await queryInterface.addIndex('product_stocks', ['quantity'], {
+      name: 'product_stocks_quantity',
+      using: 'BTREE'
+    });
+  }
+};

--- a/src/services/customers.js
+++ b/src/services/customers.js
@@ -1,8 +1,16 @@
-const { customers, customerAddresses, municipalities, branches, users } = require('../models/index');
+const { customers, customerAddresses, municipalities, branches, users, sequelize } = require('../models/index');
 const { Op } = require('sequelize');
 const { encrypt } = require('../utils/handlePassword');
 const { ROLE } = require('../constants/roles');
 const { SORT_WHITELIST } = require('../constants/customers');
+
+const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
+
+const buildNameSearch = (search) =>
+  sequelize.where(
+    sequelize.literal('MATCH(customers.name) AGAINST(:ftq IN BOOLEAN MODE)'),
+    { [Op.gt]: 0 }
+  );
 
 const sanitizeSort = (sortBy, sortOrder) => ({
   safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
@@ -22,8 +30,8 @@ const userAttributes = ['id', 'email', 'role'];
 const getAllCustomers = async(page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
-  const where = search ? { name: { [Op.like]: `%${search}%` } } : {};
-  const { count, rows } = await customers.findAndCountAll({
+  const where = search ? buildNameSearch(search) : {};
+  const queryOptions = {
     attributes,
     where,
     include: [
@@ -47,7 +55,9 @@ const getAllCustomers = async(page = 1, limit = 20, search = '', sortBy = 'id', 
     limit,
     offset,
     distinct: true
-  });
+  };
+  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };
 };
@@ -90,8 +100,8 @@ const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '', 
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { branch_id: branchId };
-  if (search) where.name = { [Op.like]: `%${search}%` };
-  const { count, rows } = await customers.findAndCountAll({
+  if (search) where[Op.and] = [buildNameSearch(search)];
+  const queryOptions = {
     attributes,
     where,
     include: [
@@ -111,7 +121,9 @@ const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '', 
     limit,
     offset,
     distinct: true
-  });
+  };
+  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };
 };
@@ -120,8 +132,8 @@ const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, s
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = { municipality_id: municipalityId };
-  if (search) where.name = { [Op.like]: `%${search}%` };
-  const { count, rows } = await customers.findAndCountAll({
+  if (search) where[Op.and] = [buildNameSearch(search)];
+  const queryOptions = {
     attributes,
     where,
     include: [
@@ -141,7 +153,9 @@ const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, s
     limit,
     offset,
     distinct: true
-  });
+  };
+  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };
 };

--- a/src/services/productStocks.js
+++ b/src/services/productStocks.js
@@ -1,6 +1,8 @@
-const { productStocks, stockMovements, products, branches } = require('../models/index');
+const { productStocks, stockMovements, products, branches, sequelize } = require('../models/index');
 const { Op } = require('sequelize');
 const { SORT_WHITELIST } = require('../constants/productStocks');
+
+const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
 
 const sanitizeSort = (sortBy, sortOrder) => ({
   safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
@@ -40,13 +42,21 @@ const getAllProductStocks = async (branchId = null, page = 1, limit = 20, search
     attributes: productAttributes,
     ...(search
       ? {
-          where: { [Op.or]: [{ id: { [Op.like]: `%${search}%` } }, { name: { [Op.like]: `%${search}%` } }] },
+          where: {
+            [Op.or]: [
+              { id: { [Op.like]: `%${search}%` } },
+              sequelize.where(
+                sequelize.literal('MATCH(`product`.`name`) AGAINST(:ftq IN BOOLEAN MODE)'),
+                { [Op.gt]: 0 }
+              )
+            ]
+          },
           required: true
         }
       : {})
   };
 
-  const { count, rows } = await productStocks.findAndCountAll({
+  const queryOptions = {
     attributes,
     where,
     include: [
@@ -59,7 +69,10 @@ const getAllProductStocks = async (branchId = null, page = 1, limit = 20, search
     ],
     limit,
     offset
-  });
+  };
+  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+
+  const { count, rows } = await productStocks.findAndCountAll(queryOptions);
   return { stocks: rows, total: count };
 };
 

--- a/src/services/products.js
+++ b/src/services/products.js
@@ -1,5 +1,7 @@
-const { products, productCategories, campaigns: Campaigns, campaignProducts: CampaignProducts, campaignProductBranches: CampaignProductBranches, branches: Branches } = require('../models/index');
+const { products, productCategories, campaigns: Campaigns, campaignProducts: CampaignProducts, campaignProductBranches: CampaignProductBranches, branches: Branches, sequelize } = require('../models/index');
 const { Op } = require('sequelize');
+
+const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
 
 const attributes = [
   'id',
@@ -29,9 +31,17 @@ const categoryAttributes = ['id', 'name'];
 const getAllProducts = async(page = 1, limit = 20, search = '') => {
   const offset = (page - 1) * limit;
   const where = search
-    ? { [Op.or]: [{ id: { [Op.like]: `%${search}%` } }, { name: { [Op.like]: `%${search}%` } }] }
+    ? {
+        [Op.or]: [
+          { id: { [Op.like]: `%${search}%` } },
+          sequelize.where(
+            sequelize.literal('MATCH(name) AGAINST(:ftq IN BOOLEAN MODE)'),
+            { [Op.gt]: 0 }
+          )
+        ]
+      }
     : {};
-  const { count, rows } = await products.findAndCountAll({
+  const queryOptions = {
     attributes,
     where,
     include: [
@@ -44,7 +54,9 @@ const getAllProducts = async(page = 1, limit = 20, search = '') => {
     limit,
     offset,
     distinct: true
-  });
+  };
+  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  const { count, rows } = await products.findAndCountAll(queryOptions);
   return { products: rows, total: count };
 };
 


### PR DESCRIPTION
## Summary

- Add FULLTEXT index on `products.name` and `customers.name` for faster search queries
- Add compound index on `campaigns(is_active, start_date, end_date)` for active campaign lookups
- Drop redundant single-column indexes on `product_stocks` (`product_id`, `quantity`) covered by the existing compound index
- Rewrite `getAllProducts` and `getAllCustomers` services to use MATCH AGAINST instead of LIKE
- Keep `getStocksByBranch` with LIKE — bar codes contain hyphens which break FULLTEXT tokenization

## Changes

| File | Change |
|------|--------|
| `src/database/migrations/20260703000001-add-idx-campaigns-active-dates.js` | Compound index `(is_active, start_date, end_date)` on campaigns |
| `src/database/migrations/20260703000002-add-fulltext-products-name.js` | FULLTEXT index `ft_products_name` on products.name |
| `src/database/migrations/20260703000003-add-fulltext-customers-name.js` | FULLTEXT index `ft_customers_name` on customers.name |
| `src/database/migrations/20260703000004-remove-redundant-product-stocks-idx.js` | Drop `product_stocks_product_id` and `product_stocks_quantity` |
| `src/services/products.js` | MATCH AGAINST with `sanitizeFulltext` helper; LIKE fallback for id |
| `src/services/customers.js` | MATCH AGAINST on `customers.name` with table qualifier for JOIN safety |
| `src/services/productStocks.js` | LIKE kept for bar_code search (hyphen tokenization issue) |

## Test Plan

- [x] `EXPLAIN SELECT id FROM products WHERE MATCH(name) AGAINST('producto*' IN BOOLEAN MODE)` → uses `ft_products_name`, cost=1.1
- [x] `SHOW INDEX FROM product_stocks` → `product_stocks_product_id` and `product_stocks_quantity` absent; FK index `product_stocks_branch_id` preserved
- [x] Full test suite passes (`pnpm test`)
- [x] `getStocksByBranch` with hyphenated bar code (`TEST-001-1`) returns correct results via LIKE

## Notes

- FULLTEXT minimum word length is 3 chars (InnoDB default) — short searches fall back gracefully
- `sanitizeFulltext` strips FULLTEXT special chars (`+-><()~*"@`) before query to prevent syntax errors
- `product_stocks_branch_id` intentionally NOT dropped — compound index `(product_id, branch_id)` does not satisfy FK left-prefix requirement for `branch_id` alone

Part of chained PR series: Stage 1 → Stage 2 → **Stage 3 (this PR)**