### PR TITLE
feat(sales): add sales_type filter to GET /sales

### DIFF
--- a/src/controllers/sales.js
+++ b/src/controllers/sales.js
@@ -19,7 +19,8 @@ const getRecords = async (req, res) => {
     const data = matchedData(req);
     const { page, limit } = getPaginationParams(data);
     const search = data.search ?? '';
-    const { sales, total } = await getAllSales(req.branchId, page, limit, search, data.sortBy, data.sortOrder);
+    const salesType = data.sales_type ?? null;
+    const { sales, total } = await getAllSales(req.branchId, page, limit, search, data.sortBy, data.sortOrder, salesType);
     res.send(buildPaginationResponse('sales', sales, total, page, limit));
   } catch (error) {
     handleHttpError(res, `ERROR_GET_RECORDS -> ${error}`);

--- a/src/routes/sales.js
+++ b/src/routes/sales.js
@@ -62,6 +62,12 @@ const branchScope = require('../middlewares/branchScope');
  *          schema:
  *            type: string
  *          description: Texto para filtrar resultados
+ *        - in: query
+ *          name: sales_type
+ *          schema:
+ *            type: string
+ *            enum: [Contado, Credito]
+ *          description: Filtrar por tipo de venta (opcional)
  *      responses:
  *        '200':
  *          description: Lista de ventas paginada

--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -78,11 +78,12 @@ const sanitizeSort = (sortBy, sortOrder) => ({
   safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
 });
 
-const getAllSales = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC') => {
+const getAllSales = async (branchId, page = 1, limit = 20, search = '', sortBy = 'id', sortOrder = 'DESC', salesType = null) => {
   const offset = (page - 1) * limit;
   const { safeSortBy, safeSortOrder } = sanitizeSort(sortBy, sortOrder);
   const where = branchId ? { branch_id: branchId } : {};
   if (search) where.ticket = { [Op.like]: `%${search}%` };
+  if (salesType) where.sales_type = salesType;
   const { count, rows } = await sales.findAndCountAll({
     attributes: saleAttributes,
     where,

--- a/src/validators/sales.js
+++ b/src/validators/sales.js
@@ -6,6 +6,7 @@ const { paginationChecks, sortChecks } = require('./shared');
 const validateGetAll = [
   ...paginationChecks,
   check('search').optional().isString().trim(),
+  check('sales_type').optional().isIn(['Contado', 'Credito']).withMessage('sales_type must be Contado or Credito'),
   ...sortChecks(SORT_WHITELIST),
   (req, res, next) => validateResults(req, res, next)
 ];


### PR DESCRIPTION
## Summary

- Agrega query param opcional `sales_type` (`Contado` | `Credito`) al endpoint `GET /api/sales`
- Null-safe: omitir el param devuelve todos los tipos sin cambio de comportamiento
- Consistente con el mismo filtro ya implementado en `getSalesByBranch` y `getSalesByCustomer`

## Changes

| File | Change |
|------|--------|
| `src/services/sales.js` | `getAllSales` acepta `salesType = null`; aplica `where.sales_type` solo si truthy |
| `src/controllers/sales.js` | Extrae `data.sales_type ?? null` y lo pasa al servicio |
| `src/validators/sales.js` | `validateGetAll` declara `sales_type` para que `matchedData()` no lo filtre |
| `src/routes/sales.js` | JSDoc `@openapi` de `GET /sales` documentado con el nuevo query param |

## Test Plan

- [x] Suite completa pasó en el pre-commit hook (`pnpm test` — 60 suites, 1433 tests)
- [x] Lint limpio (eslint vía lint-staged)
- [x] Comportamiento sin `sales_type` sin cambios (backward compatible)