### PR TITLE
feat(reports): add ticket field to accounts-receivable response

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -1711,6 +1711,7 @@ const swaggerDefinition = {
               type: 'object',
               properties: {
                 saleId: { type: 'integer' },
+                ticket: { type: 'string', nullable: true, maxLength: 20, description: 'Número de ticket de la venta (null si no aplica)' },
                 customerId: { type: 'integer' },
                 customerName: { type: 'string' },
                 salesDate: { type: 'string', format: 'date' },

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -152,6 +152,7 @@ const getAccountsReceivable = async (branchId) => {
     sequelize.query(`
       SELECT
         s.id              AS saleId,
+        s.ticket          AS ticket,
         s.customer_id     AS customerId,
         c.name            AS customerName,
         s.sales_date      AS salesDate,
@@ -271,6 +272,7 @@ const getAccountsReceivable = async (branchId) => {
 
     return {
       saleId: sale.saleId,
+      ticket: sale.ticket || null,
       customerId: sale.customerId,
       customerName: sale.customerName,
       salesDate: sale.salesDate,


### PR DESCRIPTION
Closes #154

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Agrega `ticket` al SELECT de la query SQL en `getAccountsReceivable`
- Expone el campo en el objeto de respuesta de cada crédito (`null` si no aplica)
- Documenta el campo en el schema swagger `accountsReceivableReport`

## Changes

| File | Change |
|------|--------|
| `src/services/reports.js` | `s.ticket AS ticket` en SELECT; `ticket` en el objeto de retorno |
| `docs/swagger.js` | Campo `ticket` (string, nullable, maxLength 20) en `accountsReceivableReport` |

## Test Plan
- [x] Suite completa: 60 suites, 1433 tests — todos en verde
- [x] Campo ya existe en modelo y migración (`add-ticket-to-sales`), sin cambio de schema DB

## Contributor Checklist
- [x] Issue aprobado vinculado (#154)
- [x] Exactamente un label `type:*` agregado
- [x] Conventional commit format
- [x] Sin trailers `Co-Authored-By`