### PR TITLE
feat(reports): add ticket field to daily-movement credits, cash and payments

### DIFF
--- a/docs/swagger.js
+++ b/docs/swagger.js
@@ -1795,6 +1795,7 @@ const swaggerDefinition = {
               type: 'object',
               properties: {
                 saleId: { type: 'integer' },
+                ticket: { type: 'string', nullable: true, maxLength: 20, description: 'Número de ticket de la venta (null si no aplica)' },
                 productName: { type: 'string' },
                 customerName: { type: 'string' },
                 customerAddress: { type: 'string', nullable: true },
@@ -1812,6 +1813,7 @@ const swaggerDefinition = {
               type: 'object',
               properties: {
                 saleId: { type: 'integer' },
+                ticket: { type: 'string', nullable: true, maxLength: 20, description: 'Número de ticket de la venta (null si no aplica)' },
                 qty: { type: 'number', format: 'decimal' },
                 productName: { type: 'string' },
                 customerName: { type: 'string' },
@@ -1840,6 +1842,7 @@ const swaggerDefinition = {
               type: 'object',
               properties: {
                 saleId: { type: 'integer' },
+                ticket: { type: 'string', nullable: true, maxLength: 20, description: 'Número de ticket de la venta (null si no aplica)' },
                 customerName: { type: 'string' },
                 paymentDate: { type: 'string', format: 'date' },
                 amount: { type: 'number', format: 'decimal' },

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -8,6 +8,7 @@ const getDailyMovement = async (branchId, date) => {
     sequelize.query(`
       SELECT
         sd.sale_id          AS saleId,
+        s.ticket            AS ticket,
         p.name              AS productName,
         c.name              AS customerName,
         TRIM(CONCAT(ca.street,
@@ -35,6 +36,7 @@ const getDailyMovement = async (branchId, date) => {
     sequelize.query(`
       SELECT
         sd.sale_id    AS saleId,
+        s.ticket      AS ticket,
         sd.qty,
         p.name        AS productName,
         c.name        AS customerName,
@@ -70,6 +72,7 @@ const getDailyMovement = async (branchId, date) => {
     sequelize.query(`
       SELECT
         sp.sale_id          AS saleId,
+        s.ticket            AS ticket,
         c.name              AS customerName,
         sp.payment_date     AS paymentDate,
         sp.payment_amount   AS amount,


### PR DESCRIPTION
Closes #156

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Agrega `s.ticket AS ticket` al SELECT de la query `credits` (ventas a crédito)
- Agrega `s.ticket AS ticket` al SELECT de la query `cash` (ventas de contado)
- Agrega `s.ticket AS ticket` al SELECT de la query `payments` (abonos)
- Documenta el campo `ticket` (string, nullable, maxLength 20) en las tres secciones del schema swagger `dailyMovementReport`

## Changes

| File | Change |
|------|--------|
| `src/services/reports.js` | `s.ticket AS ticket` en los tres SELECTs de `getDailyMovement` |
| `docs/swagger.js` | Campo `ticket` en `credits`, `cash` y `payments` del schema `dailyMovementReport` |

## Test Plan
- [x] Suite completa: 60 suites, 1433 tests — todos en verde
- [x] Sin cambio de schema DB — campo ya existe en modelo y migración

## Contributor Checklist
- [x] Issue aprobado vinculado (#156)
- [x] Exactamente un label `type:*` agregado
- [x] Conventional commit format
- [x] Sin trailers `Co-Authored-By`