### PR TITLE
fix(server): set keepAliveTimeout and headersTimeout to prevent ERR_NETWORK_CHANGED on Railway

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -27,7 +27,7 @@ class Server {
   }
 
   stop() {
-    this.app.close();
+    if (this.httpServer) this.httpServer.close();
   }
 
   async dbConnect() {
@@ -158,11 +158,16 @@ class Server {
   }
 
   listen() {
-    this.app.listen(this.port, () => {
+    this.httpServer = this.app.listen(this.port, () => {
       logger.info(`Server running on port ${this.port}`);
       logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
       logger.info(`Swagger documentation available at: http://localhost:${this.port}/documentation`);
     });
+
+    // Railway's load balancer closes idle keep-alive connections after ~75s.
+    // Node.js must close its end first to avoid mid-request ERR_NETWORK_CHANGED.
+    this.httpServer.keepAliveTimeout = 120000; // 120s > Railway LB timeout
+    this.httpServer.headersTimeout = 125000; // must be > keepAliveTimeout
   }
 }
 


### PR DESCRIPTION
Closes #158

## Summary

- Captura la instancia `http.Server` en `listen()` para poder configurar timeouts de conexión
- Establece `keepAliveTimeout = 120s` (mayor al timeout del LB de Railway ~75s)
- Establece `headersTimeout = 125s` (requerido: debe ser > `keepAliveTimeout`)
- Corrige `stop()` que llamaba `this.app.close()` (inexistente) en lugar de `this.httpServer.close()`

## Test plan

- [ ] Tests locales pasan (`pnpm test`)
- [ ] Deployar en UAT y verificar que `ERR_NETWORK_CHANGED` no ocurre en requests que antes fallaban
- [ ] Confirmar con el frontend que el retry ya no es necesario dispararse con frecuencia