### PR TITLE
fix(search): use AND boolean mode and LIKE fallback for short FULLTEXT queries

### DIFF
--- a/src/services/customers.js
+++ b/src/services/customers.js
@@ -6,11 +6,22 @@ const { SORT_WHITELIST } = require('../constants/customers');
 
 const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
 
-const buildNameSearch = (search) =>
-  sequelize.where(
+const buildFulltextQuery = (search) => {
+  const words = sanitizeFulltext(search).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '';
+  // Each word required (+); last word gets prefix wildcard (*) for incremental search
+  return words.map((w, i) => i === words.length - 1 ? `+${w}*` : `+${w}`).join(' ');
+};
+
+const buildNameSearch = (search) => {
+  if (search.length < 3) {
+    return { name: { [Op.like]: `%${search}%` } };
+  }
+  return sequelize.where(
     sequelize.literal('MATCH(customers.name) AGAINST(:ftq IN BOOLEAN MODE)'),
     { [Op.gt]: 0 }
   );
+};
 
 const sanitizeSort = (sortBy, sortOrder) => ({
   safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
@@ -56,7 +67,7 @@ const getAllCustomers = async(page = 1, limit = 20, search = '', sortBy = 'id', 
     offset,
     distinct: true
   };
-  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  if (search && search.length >= 3) queryOptions.replacements = { ftq: buildFulltextQuery(search) };
   const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };
@@ -122,7 +133,7 @@ const getCustomersByBranch = async(branchId, page = 1, limit = 20, search = '', 
     offset,
     distinct: true
   };
-  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  if (search && search.length >= 3) queryOptions.replacements = { ftq: buildFulltextQuery(search) };
   const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };
@@ -154,7 +165,7 @@ const getCustomersByMunicipality = async(municipalityId, page = 1, limit = 20, s
     offset,
     distinct: true
   };
-  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  if (search && search.length >= 3) queryOptions.replacements = { ftq: buildFulltextQuery(search) };
   const { count, rows } = await customers.findAndCountAll(queryOptions);
 
   return { customers: rows, total: count };

--- a/src/services/productStocks.js
+++ b/src/services/productStocks.js
@@ -4,6 +4,12 @@ const { SORT_WHITELIST } = require('../constants/productStocks');
 
 const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
 
+const buildFulltextQuery = (search) => {
+  const words = sanitizeFulltext(search).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '';
+  return words.map((w, i) => i === words.length - 1 ? `+${w}*` : `+${w}`).join(' ');
+};
+
 const sanitizeSort = (sortBy, sortOrder) => ({
   safeSortBy: SORT_WHITELIST.includes(sortBy) ? sortBy : 'id',
   safeSortOrder: sortOrder === 'ASC' ? 'ASC' : 'DESC'
@@ -45,10 +51,12 @@ const getAllProductStocks = async (branchId = null, page = 1, limit = 20, search
           where: {
             [Op.or]: [
               { id: { [Op.like]: `%${search}%` } },
-              sequelize.where(
-                sequelize.literal('MATCH(`product`.`name`) AGAINST(:ftq IN BOOLEAN MODE)'),
-                { [Op.gt]: 0 }
-              )
+              search.length >= 3
+                ? sequelize.where(
+                  sequelize.literal('MATCH(`product`.`name`) AGAINST(:ftq IN BOOLEAN MODE)'),
+                  { [Op.gt]: 0 }
+                )
+                : { name: { [Op.like]: `%${search}%` } }
             ]
           },
           required: true
@@ -70,7 +78,7 @@ const getAllProductStocks = async (branchId = null, page = 1, limit = 20, search
     limit,
     offset
   };
-  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  if (search && search.length >= 3) queryOptions.replacements = { ftq: buildFulltextQuery(search) };
 
   const { count, rows } = await productStocks.findAndCountAll(queryOptions);
   return { stocks: rows, total: count };

--- a/src/services/products.js
+++ b/src/services/products.js
@@ -3,6 +3,12 @@ const { Op } = require('sequelize');
 
 const sanitizeFulltext = (str) => str.replace(/[+\-><()~*"@]/g, ' ').trim();
 
+const buildFulltextQuery = (search) => {
+  const words = sanitizeFulltext(search).split(/\s+/).filter(Boolean);
+  if (words.length === 0) return '';
+  return words.map((w, i) => i === words.length - 1 ? `+${w}*` : `+${w}`).join(' ');
+};
+
 const attributes = [
   'id',
   'barcode',
@@ -30,14 +36,17 @@ const categoryAttributes = ['id', 'name'];
 
 const getAllProducts = async(page = 1, limit = 20, search = '') => {
   const offset = (page - 1) * limit;
+  const useFulltext = search && search.length >= 3;
   const where = search
     ? {
         [Op.or]: [
           { id: { [Op.like]: `%${search}%` } },
-          sequelize.where(
-            sequelize.literal('MATCH(products.name) AGAINST(:ftq IN BOOLEAN MODE)'),
-            { [Op.gt]: 0 }
-          )
+          useFulltext
+            ? sequelize.where(
+              sequelize.literal('MATCH(products.name) AGAINST(:ftq IN BOOLEAN MODE)'),
+              { [Op.gt]: 0 }
+            )
+            : { name: { [Op.like]: `%${search}%` } }
         ]
       }
     : {};
@@ -55,7 +64,7 @@ const getAllProducts = async(page = 1, limit = 20, search = '') => {
     offset,
     distinct: true
   };
-  if (search) queryOptions.replacements = { ftq: sanitizeFulltext(search) + '*' };
+  if (useFulltext) queryOptions.replacements = { ftq: buildFulltextQuery(search) };
   const { count, rows } = await products.findAndCountAll(queryOptions);
   return { products: rows, total: count };
 };


### PR DESCRIPTION
Closes #160

## Summary

- `buildFulltextQuery`: cada palabra recibe prefijo `+` (requerida); la última palabra recibe `*` para prefix matching — `"gerardo vargas"` → `"+gerardo +vargas*"`
- Búsquedas < 3 chars usan `LIKE %term%` como fallback (InnoDB no indexa tokens menores a `innodb_ft_min_token_size`)
- Aplica a `customers.js`, `products.js` y `productStocks.js`

## Test plan

- [ ] Buscar cliente por nombre compuesto (ej: "Juan García") → solo retorna quien tiene ambas palabras
- [ ] Buscar con 1-2 caracteres → retorna resultados via LIKE (no vacío)
- [ ] Buscar con una sola palabra → comportamiento igual al anterior
- [ ] Tests completos pasan (`pnpm test`)