### PR TITLE
perf(sales): replace two-step IN-list with SQL subquery for overdue sales

### DIFF
--- a/src/services/sales.js
+++ b/src/services/sales.js
@@ -4,7 +4,7 @@ const {
   productStocks, stockMovements, campaignProducts, accountingVouchers: avModel
 } = require('../models/index');
 const { sequelize } = require('../models/index');
-const { Op } = require('sequelize');
+const { Op, literal } = require('sequelize');
 const accountingEngine = require('./accountingEngine.service');
 const { cancelVoucher } = require('./accountingVouchers');
 const { TICKET_CONFIG, SORT_WHITELIST } = require('../constants/sales');
@@ -140,16 +140,12 @@ const getOverdueSales = async (page = 1, limit = 20, search = '') => {
   const offset = (page - 1) * limit;
   const today = new Date().toISOString().split('T')[0];
 
-  const overdueRows = await saleInstallments.findAll({
-    where: { status: 'Pendiente', due_date: { [Op.lt]: today } },
-    attributes: ['sale_id'],
-    group: ['sale_id']
-  });
-  const overdueSaleIds = overdueRows.map(r => r.sale_id);
-  if (overdueSaleIds.length === 0) return { sales: [], total: 0 };
-
   const where = {
-    id: { [Op.in]: overdueSaleIds },
+    id: {
+      [Op.in]: literal(
+        `(SELECT DISTINCT sale_id FROM sale_installments WHERE status = 'Pendiente' AND due_date < '${today}')`
+      )
+    },
     sales_type: 'Credito',
     status: 'Pendiente'
   };


### PR DESCRIPTION
## Summary

- Eliminates a redundant round-trip to Node.js in `getOverdueSales`
- Previously: fetched all overdue `sale_id`s into memory, then passed them as a potentially huge `IN(id1, id2, ..., idN)` list
- Now: a single SQL query with an `IN (SELECT DISTINCT sale_id ...)` subquery that MySQL optimizes as a semi-join

## Changes

| File | Change |
|------|--------|
| `src/services/sales.js` | Remove first `findAll` query; replace `IN([...ids])` with `IN(subquery)` via Sequelize `literal` |

## Why this matters

The previous approach materializes the result set in the application layer before sending it back to the database. With a large number of overdue sales, the `IN(...)` list grows linearly and can degrade both query parsing and execution. MySQL's semi-join optimizer handles the subquery more efficiently using index access on `sale_installments`.

> **Recommended index** (if not already present): `(status, due_date, sale_id)` on `sale_installments` to support the subquery filter.

## Test Plan

- [x] All tests pass (`pnpm test`)
- [x] No functional change — same rows returned, same response shape