### PR TITLE
feat(stock-movements): expose paginated product movement history endpoint

### DIFF
--- a/src/constants/modules.js
+++ b/src/constants/modules.js
@@ -464,6 +464,12 @@ const LOYALTY = Object.freeze({
   NAME_ADJUST_POINTS: 'Ajustar puntos de clientes'
 });
 
+const STOCK_MOVEMENT = Object.freeze({
+  MODULE_NAME: 'stockMovements',
+  VIEW_BY_PRODUCT: 'view_stock_movements_by_product',
+  NAME_VIEW_BY_PRODUCT: 'Ver movimientos de inventario por producto'
+});
+
 const REPORTS = Object.freeze({
   MODULE_NAME: 'reports',
   VIEW_DAILY_MOVEMENT: 'view_daily_movement',
@@ -510,5 +516,6 @@ module.exports = {
   ACCOUNTING_VOUCHER,
   ACCOUNTING_REPORT,
   LOYALTY,
-  REPORTS
+  REPORTS,
+  STOCK_MOVEMENT
 };

--- a/src/controllers/stockMovements.js
+++ b/src/controllers/stockMovements.js
@@ -1,0 +1,18 @@
+const { matchedData } = require('express-validator');
+const { handleHttpError } = require('../utils/handleErorr');
+const { getPaginationParams, buildPaginationResponse } = require('../utils/pagination');
+const { getMovementsByProduct } = require('../services/stockMovements');
+
+const getMovementsByProductHandler = async (req, res) => {
+  try {
+    const data = matchedData(req);
+    const { page, limit } = getPaginationParams(data);
+    const sortOrder = data.sortOrder ?? 'ASC';
+    const { movements, total } = await getMovementsByProduct(data.product_id, page, limit, sortOrder);
+    res.send(buildPaginationResponse('movements', movements, total, page, limit));
+  } catch (error) {
+    handleHttpError(res, `ERROR_GET_MOVEMENTS_BY_PRODUCT -> ${error}`, 400);
+  }
+};
+
+module.exports = { getMovementsByProductHandler };

--- a/src/database/seeders/json_files/privileges.js
+++ b/src/database/seeders/json_files/privileges.js
@@ -4,7 +4,7 @@ const {
   CUSTOMER: CUST, CUSTOMER_ADDRESS: CUSTADDR, PRODUCT_CATEGORY: CATP, USER_BRANCH: UBR, PRODUCT: PRD, POSITION: POS, PRICE_LIST: PL,
   PRODUCT_PRICE: PP, PURCHASE: PURCH, PRODUCT_STOCK: PS, SUPPLIER: SUP, PURCH_PAYMENT: PP_PAY, TRANSFER: TRANSF,
   SALE_PAYMENT: SL_PAY, DRIVER: DRV, LOYALTY: LY, ACCOUNTING_REPORT: AC_RPT, ACCOUNTING_ACCOUNT: AC_AC,
-  REPORTS: REPORT
+  REPORTS: REPORT, STOCK_MOVEMENT: SM
 } = require('../../../constants/modules');
 
 const data = [
@@ -203,7 +203,10 @@ const data = [
   // reports
   { name: REPORT.NAME_DAILY_MOVEMENT, codeName: REPORT.VIEW_DAILY_MOVEMENT, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha },
   { name: REPORT.NAME_ACCOUNTS_RECEIVABLE, codeName: REPORT.VIEW_ACCOUNTS_RECEIVABLE, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha },
-  { name: REPORT.NAME_INVENTORY, codeName: REPORT.VIEW_INVENTORY, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha }
+  { name: REPORT.NAME_INVENTORY, codeName: REPORT.VIEW_INVENTORY, module: REPORT.MODULE_NAME, created_at: fecha, updated_at: fecha },
+
+  // Movimientos de inventario
+  { name: SM.NAME_VIEW_BY_PRODUCT, codeName: SM.VIEW_BY_PRODUCT, module: SM.MODULE_NAME, created_at: fecha, updated_at: fecha }
 
 ];
 

--- a/src/routes/stockMovements.js
+++ b/src/routes/stockMovements.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const router = express.Router();
+
+const { validateGetByProduct } = require('../validators/stockMovements');
+const authMidleware = require('../middlewares/session');
+const checkRol = require('../middlewares/rol');
+const { searchLimiter } = require('../middlewares/rateLimiters');
+const { getMovementsByProductHandler } = require('../controllers/stockMovements');
+const { STOCK_MOVEMENT } = require('../constants/modules');
+const { ROLE } = require('../constants/roles');
+
+/**
+ * @openapi
+ * /stockMovements/product/{product_id}:
+ *   get:
+ *     tags:
+ *       - stockMovements
+ *     summary: Movimientos de inventario por producto
+ *     description: Obtener el historial paginado de movimientos de stock de un producto en todas las sucursales
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: product_id
+ *         in: path
+ *         description: Identificador del producto
+ *         required: true
+ *         schema:
+ *           type: string
+ *           maxLength: 20
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Número de página
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Registros por página
+ *       - in: query
+ *         name: sortOrder
+ *         schema:
+ *           type: string
+ *           enum: [ASC, DESC]
+ *           default: ASC
+ *         description: Orden por fecha de creación (ASC = más antiguo primero)
+ *     responses:
+ *       '200':
+ *         description: Lista paginada de movimientos de inventario del producto
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 movements:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/stockMovements'
+ *                 pagination:
+ *                   $ref: '#/components/schemas/pagination'
+ *       '400':
+ *         description: Error al obtener los movimientos
+ *       '422':
+ *         description: Error de validación
+ */
+router.get('/product/:product_id', [
+  searchLimiter,
+  authMidleware,
+  validateGetByProduct,
+  checkRol([ROLE.USER, ROLE.ADMIN], STOCK_MOVEMENT.VIEW_BY_PRODUCT)
+], getMovementsByProductHandler);
+
+module.exports = router;

--- a/src/services/stockMovements.js
+++ b/src/services/stockMovements.js
@@ -22,8 +22,11 @@ const getAllMovements = async (filters = {}) => {
   return result;
 };
 
-const getMovementsByProduct = async (productId) => {
-  const result = await stockMovements.findAll({
+const getMovementsByProduct = async (productId, page = 1, limit = 20, sortOrder = 'ASC') => {
+  const offset = (page - 1) * limit;
+  const order = sortOrder === 'DESC' ? 'DESC' : 'ASC';
+
+  const { count, rows } = await stockMovements.findAndCountAll({
     attributes: movementAttributes,
     where: { product_id: productId },
     include: [
@@ -33,10 +36,12 @@ const getMovementsByProduct = async (productId) => {
         attributes: ['id', 'name']
       }
     ],
-    order: [['created_at', 'DESC']]
+    order: [['created_at', order]],
+    limit,
+    offset
   });
 
-  return result;
+  return { movements: rows, total: count };
 };
 
 const getMovementsByBranch = async (branchId) => {

--- a/src/validators/stockMovements.js
+++ b/src/validators/stockMovements.js
@@ -1,0 +1,19 @@
+const { check } = require('express-validator');
+const validateResults = require('../utils/handleValidator');
+const { paginationChecks } = require('./shared');
+
+const validateGetByProduct = [
+  check('product_id')
+    .exists().withMessage('product_id es requerido').bail()
+    .notEmpty().withMessage('product_id no puede estar vacío').bail()
+    .isString().withMessage('product_id debe ser un texto').bail()
+    .isLength({ max: 20 }).withMessage('product_id no puede superar 20 caracteres').bail(),
+  ...paginationChecks,
+  check('sortOrder')
+    .optional()
+    .isString().trim()
+    .isIn(['ASC', 'DESC']).withMessage('sortOrder debe ser ASC o DESC'),
+  (req, res, next) => validateResults(req, res, next)
+];
+
+module.exports = { validateGetByProduct };


### PR DESCRIPTION
## Summary

- Add `GET /api/stockMovements/product/:product_id` — paginated, sortable movement history per product
- Validator enforces `product_id`, `page`, `limit`, and `sortOrder` (ASC/DESC, default ASC)
- Seeder adds `view_stock_movements_by_product` privilege; `STOCK_MOVEMENT` module constant registered

## Test plan

- [ ] `GET /api/stockMovements/product/:product_id` returns paginated results with `total`, `page`, `totalPages`, and `data`
- [ ] `sortOrder=DESC` returns movements newest-first; default (ASC) returns oldest-first
- [ ] Invalid `product_id` (non-integer) returns 422 validation error
- [ ] Request without valid JWT returns 401
- [ ] User without `view_stock_movements_by_product` privilege returns 403
- [ ] Full test suite passes (`pnpm test`)